### PR TITLE
[maintenance] fix docblock for better PHPStorm autocomplete suggestions

### DIFF
--- a/src/Select.php
+++ b/src/Select.php
@@ -25,14 +25,14 @@ use Spiral\Pagination\PaginableInterface;
  *
  * Trait provides the ability to transparently configure underlying loader query.
  *
- * @method $this distinct()
- * @method $this where(...$args);
- * @method $this andWhere(...$args);
- * @method $this orWhere(...$args);
- * @method $this having(...$args);
- * @method $this andHaving(...$args);
- * @method $this orHaving(...$args);
- * @method $this orderBy($expression, $direction = 'ASC');
+ * @method self distinct()
+ * @method self where(...$args);
+ * @method self andWhere(...$args);
+ * @method self orWhere(...$args);
+ * @method self having(...$args);
+ * @method self andHaving(...$args);
+ * @method self orHaving(...$args);
+ * @method self orderBy($expression, $direction = 'ASC');
  *
  * @method int avg($identifier) Perform aggregation (AVG) based on column or expression value.
  * @method int min($identifier) Perform aggregation (MIN) based on column or expression value.
@@ -82,7 +82,7 @@ final class Select implements \IteratorAggregate, \Countable, PaginableInterface
      *
      * @param string $name
      * @param array  $arguments
-     * @return $this|mixed
+     * @return self|mixed
      */
     public function __call(string $name, array $arguments)
     {


### PR DESCRIPTION
Make a small change in docblock typehint according https://docs.phpdoc.org/guides/types.html#keywords for better autocomplete in PHPStrorm