### PR TITLE
Add possibility to change default schema classes

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -54,8 +54,7 @@ final class Factory implements FactoryInterface
         RelationConfig $config = null,
         CoreFactory $factory = null,
         ContainerInterface $container = null
-    )
-    {
+    ) {
         $this->dbal = $dbal;
         $this->config = $config ?? RelationConfig::getDefault();
         $this->factory = $factory ?? new Container();
@@ -71,8 +70,10 @@ final class Factory implements FactoryInterface
     /**
      * @inheritdoc
      */
-    public function make(string $alias, array $parameters = [])
-    {
+    public function make(
+        string $alias,
+        array $parameters = []
+    ) {
         return $this->factory->make($alias, $parameters);
     }
 
@@ -83,8 +84,7 @@ final class Factory implements FactoryInterface
         ORMInterface $orm,
         SchemaInterface $schema,
         string $role
-    ): MapperInterface
-    {
+    ): MapperInterface {
         $class = $schema->define($role, Schema::MAPPER) ?? $this->defaults[Schema::MAPPER];
 
         if (!is_subclass_of($class, MapperInterface::class)) {
@@ -106,8 +106,7 @@ final class Factory implements FactoryInterface
         SchemaInterface $schema,
         string $role,
         string $relation
-    ): LoaderInterface
-    {
+    ): LoaderInterface {
         $schema = $schema->defineRelation($role, $relation);
 
         return $this->config->getLoader($schema[Relation::TYPE])->resolve($this->factory, [
@@ -126,8 +125,7 @@ final class Factory implements FactoryInterface
         SchemaInterface $schema,
         string $role,
         string $relation
-    ): RelationInterface
-    {
+    ): RelationInterface {
         $relSchema = $schema->defineRelation($role, $relation);
         $type = $relSchema[Relation::TYPE];
 
@@ -151,9 +149,10 @@ final class Factory implements FactoryInterface
      * @inheritDoc
      */
     public function repository(
-        SchemaInterface $schema, string $role, ?Select $select
-    ): RepositoryInterface
-    {
+        SchemaInterface $schema,
+        string $role,
+        ?Select $select
+    ): RepositoryInterface {
         $class = $schema->define($role, Schema::REPOSITORY) ?? $this->defaults[Schema::REPOSITORY];
 
         if (!is_subclass_of($class, RepositoryInterface::class)) {
@@ -170,8 +169,7 @@ final class Factory implements FactoryInterface
         ORMInterface $orm,
         SchemaInterface $schema,
         string $role
-    ): SourceInterface
-    {
+    ): SourceInterface {
         $source = $schema->define($role, Schema::SOURCE) ?? $this->defaults[Schema::SOURCE];
 
         if (!is_subclass_of($source, SourceInterface::class)) {
@@ -188,18 +186,16 @@ final class Factory implements FactoryInterface
         );
 
         $constrain = $schema->define($role, Schema::CONSTRAIN) ?? $this->defaults[Schema::CONSTRAIN];
-        if ($constrain !== null) {
 
-            if (!is_subclass_of($constrain, ConstrainInterface::class)) {
-                throw new TypecastException($constrain . ' not implement ConstrainInterface');
-            }
-
-            $source = $source->withConstrain(
-                is_object($constrain) ? $constrain : $this->factory->make($constrain)
-            );
+        if (!is_subclass_of($constrain, ConstrainInterface::class)) {
+            throw new TypecastException($constrain . ' not implement ConstrainInterface');
         }
 
-        return $source;
+        if ($constrain === null) {
+            return $source;
+        }
+
+        return $source->withConstrain(is_object($constrain) ? $constrain : $this->factory->make($constrain));
     }
 
     /**

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -151,10 +151,7 @@ final class Factory implements FactoryInterface
      * @inheritDoc
      */
     public function repository(
-        ORMInterface $orm,
-        SchemaInterface $schema,
-        string $role,
-        ?Select $select
+        SchemaInterface $schema, string $role, ?Select $select
     ): RepositoryInterface
     {
         $class = $schema->define($role, Schema::REPOSITORY) ?? $this->defaults[Schema::REPOSITORY];
@@ -163,11 +160,7 @@ final class Factory implements FactoryInterface
             throw new TypecastException($class . ' not implement RepositoryInterface');
         }
 
-        return $this->factory->make($class, [
-            'orm' => $orm,
-            'role' => $role,
-            'select' => $select
-        ]);
+        return $this->factory->make($class, ['select' => $select]);
     }
 
     /**
@@ -218,7 +211,7 @@ final class Factory implements FactoryInterface
     {
         $clone = clone $this;
 
-        $clone->defaults = array_merge($this->defaults, $defaults);
+        $clone->defaults = $defaults + $this->defaults;
 
         return $clone;
     }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -190,7 +190,7 @@ final class Factory implements FactoryInterface
         }
 
         $source = new Source(
-            $this->factory->database($schema->define($role, Schema::DATABASE)),
+            $this->database($schema->define($role, Schema::DATABASE)),
             $schema->define($role, Schema::TABLE)
         );
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -12,9 +12,14 @@ declare(strict_types=1);
 namespace Cycle\ORM;
 
 use Cycle\ORM\Config\RelationConfig;
+use Cycle\ORM\Exception\TypecastException;
 use Cycle\ORM\Mapper\Mapper;
 use Cycle\ORM\Relation\RelationInterface;
+use Cycle\ORM\Select\ConstrainInterface;
 use Cycle\ORM\Select\LoaderInterface;
+use Cycle\ORM\Select\Repository;
+use Cycle\ORM\Select\Source;
+use Cycle\ORM\Select\SourceInterface;
 use Psr\Container\ContainerInterface;
 use Spiral\Core\Container;
 use Spiral\Core\FactoryInterface as CoreFactory;
@@ -35,22 +40,32 @@ final class Factory implements FactoryInterface
     /** @var DatabaseProviderInterface */
     private $dbal;
 
+    /** @var array<string, string> */
+    private $defaults = [];
+
     /**
      * @param DatabaseProviderInterface $dbal
-     * @param RelationConfig            $config
-     * @param CoreFactory|null          $factory
-     * @param ContainerInterface|null   $container
+     * @param RelationConfig $config
+     * @param CoreFactory|null $factory
+     * @param ContainerInterface|null $container
      */
     public function __construct(
         DatabaseProviderInterface $dbal,
         RelationConfig $config = null,
         CoreFactory $factory = null,
         ContainerInterface $container = null
-    ) {
+    )
+    {
         $this->dbal = $dbal;
         $this->config = $config ?? RelationConfig::getDefault();
         $this->factory = $factory ?? new Container();
         $this->container = $container ?? new Container();
+        $this->defaults = [
+            Schema::REPOSITORY => Repository::class,
+            Schema::SOURCE => Source::class,
+            Schema::MAPPER => Mapper::class,
+            Schema::CONSTRAIN => null,
+        ];
     }
 
     /**
@@ -68,12 +83,17 @@ final class Factory implements FactoryInterface
         ORMInterface $orm,
         SchemaInterface $schema,
         string $role
-    ): MapperInterface {
-        $class = $schema->define($role, Schema::MAPPER) ?? Mapper::class;
+    ): MapperInterface
+    {
+        $class = $schema->define($role, Schema::MAPPER) ?? $this->defaults[Schema::MAPPER];
+
+        if (!is_subclass_of($class, MapperInterface::class)) {
+            throw new TypecastException($class . ' not implement MapperInterface');
+        }
 
         return $this->factory->make($class, [
-            'orm'    => $orm,
-            'role'   => $role,
+            'orm' => $orm,
+            'role' => $role,
             'schema' => $schema->define($role, Schema::SCHEMA)
         ]);
     }
@@ -86,12 +106,13 @@ final class Factory implements FactoryInterface
         SchemaInterface $schema,
         string $role,
         string $relation
-    ): LoaderInterface {
+    ): LoaderInterface
+    {
         $schema = $schema->defineRelation($role, $relation);
 
         return $this->config->getLoader($schema[Relation::TYPE])->resolve($this->factory, [
-            'orm'    => $orm,
-            'name'   => $relation,
+            'orm' => $orm,
+            'name' => $relation,
             'target' => $schema[Relation::TARGET],
             'schema' => $schema[Relation::SCHEMA]
         ]);
@@ -105,13 +126,14 @@ final class Factory implements FactoryInterface
         SchemaInterface $schema,
         string $role,
         string $relation
-    ): RelationInterface {
+    ): RelationInterface
+    {
         $relSchema = $schema->defineRelation($role, $relation);
         $type = $relSchema[Relation::TYPE];
 
         return $this->config->getRelation($type)->resolve($this->factory, [
-            'orm'    => $orm,
-            'name'   => $relation,
+            'orm' => $orm,
+            'name' => $relation,
             'target' => $relSchema[Relation::TARGET],
             'schema' => $relSchema[Relation::SCHEMA] + [Relation::LOAD => $relSchema[Relation::LOAD] ?? null],
         ]);
@@ -123,5 +145,81 @@ final class Factory implements FactoryInterface
     public function database(string $database = null): DatabaseInterface
     {
         return $this->dbal->database($database);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function repository(
+        ORMInterface $orm,
+        SchemaInterface $schema,
+        string $role,
+        ?Select $select
+    ): RepositoryInterface
+    {
+        $class = $schema->define($role, Schema::REPOSITORY) ?? $this->defaults[Schema::REPOSITORY];
+
+        if (!is_subclass_of($class, RepositoryInterface::class)) {
+            throw new TypecastException($class . ' not implement RepositoryInterface');
+        }
+
+        return $this->factory->make($class, [
+            'orm' => $orm,
+            'role' => $role,
+            'select' => $select
+        ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function source(
+        ORMInterface $orm,
+        SchemaInterface $schema,
+        string $role
+    ): SourceInterface
+    {
+        $source = $schema->define($role, Schema::SOURCE) ?? $this->defaults[Schema::SOURCE];
+
+        if (!is_subclass_of($source, SourceInterface::class)) {
+            throw new TypecastException($source . ' not implement SourceInterface');
+        }
+
+        if ($source !== Source::class) {
+            return $this->factory->make($source, ['orm' => $orm, 'role' => $role]);
+        }
+
+        $source = new Source(
+            $this->factory->database($schema->define($role, Schema::DATABASE)),
+            $schema->define($role, Schema::TABLE)
+        );
+
+        $constrain = $schema->define($role, Schema::CONSTRAIN) ?? $this->defaults[Schema::CONSTRAIN];
+        if ($constrain !== null) {
+
+            if (!is_subclass_of($constrain, ConstrainInterface::class)) {
+                throw new TypecastException($constrain . ' not implement ConstrainInterface');
+            }
+
+            $source = $source->withConstrain(
+                is_object($constrain) ? $constrain : $this->factory->make($constrain)
+            );
+        }
+
+        return $source;
+    }
+
+    /**
+     * Add default classes for resolve
+     * @param array $defaults
+     * @return FactoryInterface
+     */
+    public function withDefaultSchemaClasses(array $defaults): FactoryInterface
+    {
+        $clone = clone $this;
+
+        $clone->defaults = array_merge($this->defaults, $defaults);
+
+        return $clone;
     }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -149,6 +149,7 @@ final class Factory implements FactoryInterface
      * @inheritDoc
      */
     public function repository(
+        ORMInterface $orm,
         SchemaInterface $schema,
         string $role,
         ?Select $select
@@ -159,7 +160,7 @@ final class Factory implements FactoryInterface
             throw new TypecastException($class . ' not implement RepositoryInterface');
         }
 
-        return $this->factory->make($class, ['select' => $select]);
+        return $this->factory->make($class, ['select' => $select, 'orm' => $orm]);
     }
 
     /**
@@ -187,12 +188,12 @@ final class Factory implements FactoryInterface
 
         $constrain = $schema->define($role, Schema::CONSTRAIN) ?? $this->defaults[Schema::CONSTRAIN];
 
-        if (!is_subclass_of($constrain, ConstrainInterface::class)) {
-            throw new TypecastException($constrain . ' not implement ConstrainInterface');
-        }
-
         if ($constrain === null) {
             return $source;
+        }
+
+        if (!is_subclass_of($constrain, ConstrainInterface::class)) {
+            throw new TypecastException($constrain . ' not implement ConstrainInterface');
         }
 
         return $source->withConstrain(is_object($constrain) ? $constrain : $this->factory->make($constrain));

--- a/src/FactoryInterface.php
+++ b/src/FactoryInterface.php
@@ -13,6 +13,7 @@ namespace Cycle\ORM;
 
 use Cycle\ORM\Relation\RelationInterface;
 use Cycle\ORM\Select\LoaderInterface;
+use Cycle\ORM\Select\SourceInterface;
 use Spiral\Core\FactoryInterface as CoreFactory;
 use Spiral\Database\DatabaseProviderInterface;
 
@@ -24,9 +25,9 @@ interface FactoryInterface extends DatabaseProviderInterface, CoreFactory
     /**
      * Create mapper associated with given role.
      *
-     * @param ORMInterface    $orm
+     * @param ORMInterface $orm
      * @param SchemaInterface $schema
-     * @param string          $role
+     * @param string $role
      * @return MapperInterface
      */
     public function mapper(
@@ -38,10 +39,10 @@ interface FactoryInterface extends DatabaseProviderInterface, CoreFactory
     /**
      * Create loader associated with specific entity and relation.
      *
-     * @param ORMInterface    $orm
+     * @param ORMInterface $orm
      * @param SchemaInterface $schema
-     * @param string          $role
-     * @param string          $relation
+     * @param string $role
+     * @param string $relation
      * @return LoaderInterface
      */
     public function loader(
@@ -51,13 +52,44 @@ interface FactoryInterface extends DatabaseProviderInterface, CoreFactory
         string $relation
     ): LoaderInterface;
 
+
+    /**
+     * Create repository associated with given role,
+     *
+     * @param ORMInterface $orm
+     * @param SchemaInterface $schema
+     * @param string $role
+     * @param Select $select
+     * @return RepositoryInterface
+     */
+    public function repository(
+        ORMInterface $orm,
+        SchemaInterface $schema,
+        string $role,
+        ?Select $select
+    ): RepositoryInterface;
+
+    /**
+     * Create source associated with given role
+     *
+     * @param ORMInterface $orm
+     * @param SchemaInterface $schema
+     * @param string $role
+     * @return SourceInterface
+     */
+    public function source(
+        ORMInterface $orm,
+        SchemaInterface $schema,
+        string $role
+    ): SourceInterface;
+
     /**
      * Create relation associated with specific entity and relation.
      *
-     * @param ORMInterface    $orm
+     * @param ORMInterface $orm
      * @param SchemaInterface $schema
-     * @param string          $role
-     * @param string          $relation
+     * @param string $role
+     * @param string $relation
      * @return RelationInterface
      */
     public function relation(

--- a/src/FactoryInterface.php
+++ b/src/FactoryInterface.php
@@ -56,12 +56,14 @@ interface FactoryInterface extends DatabaseProviderInterface, CoreFactory
     /**
      * Create repository associated with given role,
      *
+     * @param ORMInterface $orm
      * @param SchemaInterface $schema
      * @param string $role
      * @param Select $select
      * @return RepositoryInterface
      */
     public function repository(
+        ORMInterface $orm,
         SchemaInterface $schema,
         string $role,
         ?Select $select

--- a/src/FactoryInterface.php
+++ b/src/FactoryInterface.php
@@ -62,7 +62,9 @@ interface FactoryInterface extends DatabaseProviderInterface, CoreFactory
      * @return RepositoryInterface
      */
     public function repository(
-        SchemaInterface $schema, string $role, ?Select $select
+        SchemaInterface $schema,
+        string $role,
+        ?Select $select
     ): RepositoryInterface;
 
     /**

--- a/src/FactoryInterface.php
+++ b/src/FactoryInterface.php
@@ -56,17 +56,13 @@ interface FactoryInterface extends DatabaseProviderInterface, CoreFactory
     /**
      * Create repository associated with given role,
      *
-     * @param ORMInterface $orm
      * @param SchemaInterface $schema
      * @param string $role
      * @param Select $select
      * @return RepositoryInterface
      */
     public function repository(
-        ORMInterface $orm,
-        SchemaInterface $schema,
-        string $role,
-        ?Select $select
+        SchemaInterface $schema, string $role, ?Select $select
     ): RepositoryInterface;
 
     /**

--- a/src/ORM.php
+++ b/src/ORM.php
@@ -268,7 +268,7 @@ final class ORM implements ORMInterface
             $select->constrain($this->getSource($role)->getConstrain());
         }
 
-        return $this->repositories[$role] = $this->factory->repository($this, $this->schema, $role, $select);
+        return $this->repositories[$role] = $this->factory->repository($this->schema, $role, $select);
     }
 
     /**

--- a/src/ORM.php
+++ b/src/ORM.php
@@ -268,7 +268,7 @@ final class ORM implements ORMInterface
             $select->constrain($this->getSource($role)->getConstrain());
         }
 
-        return $this->repositories[$role] = $this->factory->repository($this->schema, $role, $select);
+        return $this->repositories[$role] = $this->factory->repository($this, $this->schema, $role, $select);
     }
 
     /**

--- a/src/Select/PersistRepository.php
+++ b/src/Select/PersistRepository.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Cycle\ORM\Select;
+
+use Cycle\ORM\ORMInterface;
+use Cycle\ORM\Select;
+use Cycle\ORM\Transaction;
+
+class PersistRepository extends Repository
+{
+    /** @var Transaction */
+    private $transaction;
+
+    /**
+     * @param Select $select
+     * @param ORMInterface $orm
+     */
+    public function __construct(
+        Select $select,
+        ORMInterface $orm
+    ) {
+        parent::__construct($select);
+        $this->transaction = new Transaction($orm);
+    }
+
+    /**
+     * @param mixed $entity
+     * @param bool $cascade
+     *
+     * @throws \Throwable
+     */
+    public function save(
+        $entity,
+        bool $cascade = true
+    ): void {
+        $this->transaction->persist(
+            $entity,
+            $cascade ? Transaction::MODE_CASCADE : Transaction::MODE_ENTITY_ONLY
+        );
+
+        $this->transaction->run(); // transaction is clean after run
+    }
+
+    /**
+     * @param mixed $entity
+     * @param bool $cascade
+     *
+     * @throws \Throwable
+     */
+    public function delete(
+        $entity,
+        bool $cascade = true
+    ): void {
+        $this->transaction->persist(
+            $entity,
+            $cascade ? Transaction::MODE_CASCADE : Transaction::MODE_ENTITY_ONLY
+        );
+
+        $this->transaction->run(); // transaction is clean after run
+    }
+
+    /**
+     * @param $id
+     * @param bool $cascade
+     *
+     * @throws \Throwable
+     */
+    public function deleteByPK(
+        $id,
+        bool $cascade = true
+    ): void {
+        $this->delete($this->findByPK($id), $cascade);
+    }
+}

--- a/tests/ORM/FactoryTest.php
+++ b/tests/ORM/FactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cycle\ORM\Tests;
 
 use Cycle\ORM\Exception\TypecastException;
@@ -42,14 +44,14 @@ class FactoryTest extends BaseTest
         $this->factory = new Factory($this->dbal);
     }
 
-    public function testShouldMakeDefaultMapper()
+    public function testShouldMakeDefaultMapper(): void
     {
         $mapper = $this->factory->mapper($this->orm, $this->orm->getSchema(), 'user');
 
         self::assertInstanceOf(Mapper::class, $mapper);
     }
 
-    public function testShouldChangeDefaultMapperClass()
+    public function testShouldChangeDefaultMapperClass(): void
     {
         $this->factory = $this->factory->withDefaultSchemaClasses([
             Schema::MAPPER => TimestampedMapper::class,
@@ -60,7 +62,7 @@ class FactoryTest extends BaseTest
         self::assertInstanceOf(TimestampedMapper::class, $mapper);
     }
 
-    public function testShouldThrowExceptionIfDefaultMapperClassNotImplementMapperInterface()
+    public function testShouldThrowExceptionIfDefaultMapperClassNotImplementMapperInterface(): void
     {
         $this->factory = $this->factory->withDefaultSchemaClasses([
             Schema::MAPPER => User::class,
@@ -71,18 +73,19 @@ class FactoryTest extends BaseTest
         $this->factory->mapper($this->orm, $this->orm->getSchema(), 'user');
     }
 
-    public function testShouldMakeDefaultRepository()
+    public function testShouldMakeDefaultRepository(): void
     {
         $result = $this->factory->repository(
             $this->orm,
             $this->orm->getSchema(),
             'user',
-            new Select($this->orm, 'user'));
+            new Select($this->orm, 'user')
+        );
 
         self::assertInstanceOf(Repository::class, $result);
     }
 
-    public function testShouldChangeDefaultRepositoryClass()
+    public function testShouldChangeDefaultRepositoryClass(): void
     {
         $this->factory = $this->factory->withDefaultSchemaClasses([
             Schema::REPOSITORY => UserRepository::class,
@@ -92,12 +95,13 @@ class FactoryTest extends BaseTest
             $this->orm,
             $this->orm->getSchema(),
             'user',
-            new Select($this->orm, 'user'));
+            new Select($this->orm, 'user')
+        );
 
         self::assertInstanceOf(UserRepository::class, $result);
     }
 
-    public function testShouldThrowExceptionIfDefaultRepositoryClassNotImplementRepositoryInterface()
+    public function testShouldThrowExceptionIfDefaultRepositoryClassNotImplementRepositoryInterface(): void
     {
         $this->factory = $this->factory->withDefaultSchemaClasses([
             Schema::REPOSITORY => User::class,
@@ -108,14 +112,14 @@ class FactoryTest extends BaseTest
         $this->factory->repository($this->orm, $this->orm->getSchema(), 'user', new Select($this->orm, 'user'));
     }
 
-    public function testShouldMakeDefaultSource()
+    public function testShouldMakeDefaultSource(): void
     {
         $result = $this->factory->source($this->orm, $this->orm->getSchema(), 'user');
 
         self::assertInstanceOf(Source::class, $result);
     }
 
-    public function testShouldChangeDefaultSourceClass()
+    public function testShouldChangeDefaultSourceClass(): void
     {
         $this->factory = $this->factory->withDefaultSchemaClasses([
             Schema::SOURCE => DifferentSource::class,
@@ -126,7 +130,7 @@ class FactoryTest extends BaseTest
         self::assertInstanceOf(DifferentSource::class, $result);
     }
 
-    public function testShouldThrowExceptionIfDefaultSourceClassNotImplementSourceInterface()
+    public function testShouldThrowExceptionIfDefaultSourceClassNotImplementSourceInterface(): void
     {
         $this->factory = $this->factory->withDefaultSchemaClasses([
             Schema::SOURCE => User::class,

--- a/tests/ORM/FactoryTest.php
+++ b/tests/ORM/FactoryTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Cycle\ORM\Tests;
-
 
 use Cycle\ORM\Exception\TypecastException;
 use Cycle\ORM\Factory;
@@ -29,7 +27,6 @@ class FactoryTest extends BaseTest
     {
         parent::setUp();
 
-
         $this->orm = $this->withSchema(new Schema([
             User::class => [
                 Schema::ROLE => 'user',
@@ -45,14 +42,14 @@ class FactoryTest extends BaseTest
         $this->factory = new Factory($this->dbal);
     }
 
-    function testShouldMakeDefaultMapper()
+    public function testShouldMakeDefaultMapper()
     {
         $mapper = $this->factory->mapper($this->orm, $this->orm->getSchema(), 'user');
 
         self::assertInstanceOf(Mapper::class, $mapper);
     }
 
-    function testShouldChangeDefaultMapperClass()
+    public function testShouldChangeDefaultMapperClass()
     {
         $this->factory = $this->factory->withDefaultSchemaClasses([
             Schema::MAPPER => TimestampedMapper::class,
@@ -63,7 +60,7 @@ class FactoryTest extends BaseTest
         self::assertInstanceOf(TimestampedMapper::class, $mapper);
     }
 
-    function testShouldThrowExceptionIfDefaultMapperClassNotImplementMapperInterface()
+    public function testShouldThrowExceptionIfDefaultMapperClassNotImplementMapperInterface()
     {
         $this->factory = $this->factory->withDefaultSchemaClasses([
             Schema::MAPPER => User::class,
@@ -74,15 +71,14 @@ class FactoryTest extends BaseTest
         $this->factory->mapper($this->orm, $this->orm->getSchema(), 'user');
     }
 
-
-    function testShouldMakeDefaultRepository()
+    public function testShouldMakeDefaultRepository()
     {
         $result = $this->factory->repository($this->orm->getSchema(), 'user', new Select($this->orm, 'user'));
 
         self::assertInstanceOf(Repository::class, $result);
     }
 
-    function testShouldChangeDefaultRepositoryClass()
+    public function testShouldChangeDefaultRepositoryClass()
     {
         $this->factory = $this->factory->withDefaultSchemaClasses([
             Schema::REPOSITORY => UserRepository::class,
@@ -93,7 +89,7 @@ class FactoryTest extends BaseTest
         self::assertInstanceOf(UserRepository::class, $mapper);
     }
 
-    function testShouldThrowExceptionIfDefaultRepositoryClassNotImplementRepositoryInterface()
+    public function testShouldThrowExceptionIfDefaultRepositoryClassNotImplementRepositoryInterface()
     {
         $this->factory = $this->factory->withDefaultSchemaClasses([
             Schema::REPOSITORY => User::class,
@@ -104,15 +100,14 @@ class FactoryTest extends BaseTest
         $this->factory->repository($this->orm->getSchema(), 'user', new Select($this->orm, 'user'));
     }
 
-
-    function testShouldMakeDefaultSource()
+    public function testShouldMakeDefaultSource()
     {
         $result = $this->factory->source($this->orm, $this->orm->getSchema(), 'user');
 
         self::assertInstanceOf(Source::class, $result);
     }
 
-    function testShouldChangeDefaultSourceClass()
+    public function testShouldChangeDefaultSourceClass()
     {
         $this->factory = $this->factory->withDefaultSchemaClasses([
             Schema::SOURCE => DifferentSource::class,
@@ -123,7 +118,7 @@ class FactoryTest extends BaseTest
         self::assertInstanceOf(DifferentSource::class, $result);
     }
 
-    function testShouldThrowExceptionIfDefaultSourceClassNotImplementSourceInterface()
+    public function testShouldThrowExceptionIfDefaultSourceClassNotImplementSourceInterface()
     {
         $this->factory = $this->factory->withDefaultSchemaClasses([
             Schema::SOURCE => User::class,

--- a/tests/ORM/FactoryTest.php
+++ b/tests/ORM/FactoryTest.php
@@ -1,0 +1,136 @@
+<?php
+
+
+namespace Cycle\ORM\Tests;
+
+
+use Cycle\ORM\Exception\TypecastException;
+use Cycle\ORM\Factory;
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\Schema;
+use Cycle\ORM\Select;
+use Cycle\ORM\Select\Repository;
+use Cycle\ORM\Select\Source;
+use Cycle\ORM\Tests\Fixtures\DifferentSource;
+use Cycle\ORM\Tests\Fixtures\TimestampedMapper;
+use Cycle\ORM\Tests\Fixtures\User;
+use Cycle\ORM\Tests\Fixtures\UserRepository;
+
+class FactoryTest extends BaseTest
+{
+    // currently active driver
+    public const DRIVER = 'postgres';
+    /**
+     * @var Factory
+     */
+    private $factory;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+
+        $this->orm = $this->withSchema(new Schema([
+            User::class => [
+                Schema::ROLE => 'user',
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'user',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'email', 'balance'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => []
+            ]
+        ]));
+
+        $this->factory = new Factory($this->dbal);
+    }
+
+    function testShouldMakeDefaultMapper()
+    {
+        $mapper = $this->factory->mapper($this->orm, $this->orm->getSchema(), 'user');
+
+        self::assertInstanceOf(Mapper::class, $mapper);
+    }
+
+    function testShouldChangeDefaultMapperClass()
+    {
+        $this->factory = $this->factory->withDefaultSchemaClasses([
+            Schema::MAPPER => TimestampedMapper::class,
+        ]);
+
+        $mapper = $this->factory->mapper($this->orm, $this->orm->getSchema(), 'user');
+
+        self::assertInstanceOf(TimestampedMapper::class, $mapper);
+    }
+
+    function testShouldThrowExceptionIfDefaultMapperClassNotImplementMapperInterface()
+    {
+        $this->factory = $this->factory->withDefaultSchemaClasses([
+            Schema::MAPPER => User::class,
+        ]);
+
+        self::expectException(TypecastException::class);
+
+        $this->factory->mapper($this->orm, $this->orm->getSchema(), 'user');
+    }
+
+
+    function testShouldMakeDefaultRepository()
+    {
+        $result = $this->factory->repository($this->orm->getSchema(), 'user', new Select($this->orm, 'user'));
+
+        self::assertInstanceOf(Repository::class, $result);
+    }
+
+    function testShouldChangeDefaultRepositoryClass()
+    {
+        $this->factory = $this->factory->withDefaultSchemaClasses([
+            Schema::REPOSITORY => UserRepository::class,
+        ]);
+
+        $mapper = $this->factory->repository($this->orm->getSchema(), 'user', new Select($this->orm, 'user'));
+
+        self::assertInstanceOf(UserRepository::class, $mapper);
+    }
+
+    function testShouldThrowExceptionIfDefaultRepositoryClassNotImplementRepositoryInterface()
+    {
+        $this->factory = $this->factory->withDefaultSchemaClasses([
+            Schema::REPOSITORY => User::class,
+        ]);
+
+        self::expectException(TypecastException::class);
+
+        $this->factory->repository($this->orm->getSchema(), 'user', new Select($this->orm, 'user'));
+    }
+
+
+    function testShouldMakeDefaultSource()
+    {
+        $result = $this->factory->source($this->orm, $this->orm->getSchema(), 'user');
+
+        self::assertInstanceOf(Source::class, $result);
+    }
+
+    function testShouldChangeDefaultSourceClass()
+    {
+        $this->factory = $this->factory->withDefaultSchemaClasses([
+            Schema::SOURCE => DifferentSource::class,
+        ]);
+
+        $result = $this->factory->source($this->orm, $this->orm->getSchema(), 'user');
+
+        self::assertInstanceOf(DifferentSource::class, $result);
+    }
+
+    function testShouldThrowExceptionIfDefaultSourceClassNotImplementSourceInterface()
+    {
+        $this->factory = $this->factory->withDefaultSchemaClasses([
+            Schema::SOURCE => User::class,
+        ]);
+
+        self::expectException(TypecastException::class);
+
+        $this->factory->source($this->orm, $this->orm->getSchema(), 'user');
+    }
+}

--- a/tests/ORM/FactoryTest.php
+++ b/tests/ORM/FactoryTest.php
@@ -73,7 +73,7 @@ class FactoryTest extends BaseTest
 
     public function testShouldMakeDefaultRepository()
     {
-        $result = $this->factory->repository($this->orm->getSchema(), 'user', new Select($this->orm, 'user'));
+        $result = $this->factory->repository($this->orm, $this->orm->getSchema(), 'user', new Select($this->orm, 'user'));
 
         self::assertInstanceOf(Repository::class, $result);
     }
@@ -84,7 +84,7 @@ class FactoryTest extends BaseTest
             Schema::REPOSITORY => UserRepository::class,
         ]);
 
-        $mapper = $this->factory->repository($this->orm->getSchema(), 'user', new Select($this->orm, 'user'));
+        $mapper = $this->factory->repository($this->orm, $this->orm->getSchema(), 'user', new Select($this->orm, 'user'));
 
         self::assertInstanceOf(UserRepository::class, $mapper);
     }
@@ -97,7 +97,7 @@ class FactoryTest extends BaseTest
 
         self::expectException(TypecastException::class);
 
-        $this->factory->repository($this->orm->getSchema(), 'user', new Select($this->orm, 'user'));
+        $this->factory->repository($this->orm, $this->orm->getSchema(), 'user', new Select($this->orm, 'user'));
     }
 
     public function testShouldMakeDefaultSource()

--- a/tests/ORM/FactoryTest.php
+++ b/tests/ORM/FactoryTest.php
@@ -73,7 +73,11 @@ class FactoryTest extends BaseTest
 
     public function testShouldMakeDefaultRepository()
     {
-        $result = $this->factory->repository($this->orm, $this->orm->getSchema(), 'user', new Select($this->orm, 'user'));
+        $result = $this->factory->repository(
+            $this->orm,
+            $this->orm->getSchema(),
+            'user',
+            new Select($this->orm, 'user'));
 
         self::assertInstanceOf(Repository::class, $result);
     }
@@ -84,9 +88,13 @@ class FactoryTest extends BaseTest
             Schema::REPOSITORY => UserRepository::class,
         ]);
 
-        $mapper = $this->factory->repository($this->orm, $this->orm->getSchema(), 'user', new Select($this->orm, 'user'));
+        $result = $this->factory->repository(
+            $this->orm,
+            $this->orm->getSchema(),
+            'user',
+            new Select($this->orm, 'user'));
 
-        self::assertInstanceOf(UserRepository::class, $mapper);
+        self::assertInstanceOf(UserRepository::class, $result);
     }
 
     public function testShouldThrowExceptionIfDefaultRepositoryClassNotImplementRepositoryInterface()

--- a/tests/ORM/Fixtures/DifferentSource.php
+++ b/tests/ORM/Fixtures/DifferentSource.php
@@ -1,0 +1,46 @@
+<?php
+
+
+namespace Cycle\ORM\Tests\Fixtures;
+
+
+use Cycle\ORM\Select\ConstrainInterface;
+use Cycle\ORM\Select\SourceInterface;
+use Spiral\Database\DatabaseInterface;
+
+class DifferentSource implements SourceInterface
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function getDatabase(): DatabaseInterface
+    {
+        // TODO: Implement getDatabase() method.
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getTable(): string
+    {
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withConstrain(?ConstrainInterface $constrain): SourceInterface
+    {
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getConstrain(): ?ConstrainInterface
+    {
+        return null;
+    }
+}

--- a/tests/ORM/Fixtures/DifferentSource.php
+++ b/tests/ORM/Fixtures/DifferentSource.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Cycle\ORM\Tests\Fixtures;
-
 
 use Cycle\ORM\Select\ConstrainInterface;
 use Cycle\ORM\Select\SourceInterface;


### PR DESCRIPTION
I move this possibility to factory, and move initialization logic from ORM  to Factory for uniformity

Example of usage:

```
(new ORM())->withFactory(new Factory()->withDefaultSchemaClasses([
    Schema::REPOSITORY => SomeRepo::class,
    Schema::MAPPER => SomeMapper::class,
    Schema::SOURCE => SomeSource::class,
    Schema::CONSTRAIN => SomeDefaultConstrain::class,
]))
```