### PR TITLE
Cyclic refers to with auto timestamp relation bug repro

### DIFF
--- a/tests/ORM/CyclicHasManyReferencesTest.php
+++ b/tests/ORM/CyclicHasManyReferencesTest.php
@@ -1,0 +1,222 @@
+<?php
+
+/**
+ * Cycle DataMapper ORM
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests;
+
+use Cycle\ORM\Heap\Heap;
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\Relation;
+use Cycle\ORM\Schema;
+use Cycle\ORM\Select;
+use Cycle\ORM\Tests\Fixtures\CyclicRef\Comment;
+use Cycle\ORM\Tests\Fixtures\CyclicRef\Post;
+use Cycle\ORM\Tests\Fixtures\CyclicRef\TimestampedMapper;
+use Cycle\ORM\Tests\Fixtures\CyclicRef\User;
+use Cycle\ORM\Tests\Traits\TableTrait;
+use Cycle\ORM\Transaction;
+
+abstract class CyclicHasManyReferencesTest extends BaseTest
+{
+    use TableTrait;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->makeTable('user', [
+            'id'         => 'primary',
+            'email'      => 'string',
+            'created_at' => 'timestamp',
+            'updated_at' => 'timestamp',
+        ]);
+
+        $this->makeTable('post', [
+            'id'              => 'primary',
+            'title'           => 'string',
+            'content'         => 'string',
+            'last_comment_id' => 'integer,nullable',
+            'created_at'      => 'timestamp',
+            'updated_at'      => 'timestamp',
+        ]);
+
+        $this->makeTable('comment', [
+            'id'            => 'primary',
+            'post_id'       => 'integer',
+            'user_id'       => 'integer',
+            'message'       => 'string',
+            'created_at'    => 'timestamp',
+            'updated_at'    => 'timestamp',
+        ]);
+
+        $this->orm = $this->withSchema(new Schema([
+            User::class     => [
+                Schema::ROLE        => 'user',
+                Schema::MAPPER      => TimestampedMapper::class,
+                Schema::DATABASE    => 'default',
+                Schema::TABLE       => 'user',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS     => ['id', 'email', 'created_at', 'updated_at'],
+                Schema::SCHEMA      => [],
+                Schema::RELATIONS   => []
+            ],
+            Comment::class  => [
+                Schema::ROLE        => 'comment',
+                Schema::MAPPER      => TimestampedMapper::class,
+                Schema::DATABASE    => 'default',
+                Schema::TABLE       => 'comment',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS     => ['id', 'user_id', 'post_id', 'message', 'created_at', 'updated_at'],
+                Schema::SCHEMA      => [],
+                Schema::RELATIONS   => [
+                    'user'      => [
+                        Relation::TYPE   => Relation::BELONGS_TO,
+                        Relation::TARGET => User::class,
+                        Relation::SCHEMA => [
+                            Relation::CASCADE   => true,
+                            Relation::INNER_KEY => 'user_id',
+                            Relation::OUTER_KEY => 'id',
+                        ],
+                    ],
+                ]
+            ],
+            Post::class     => [
+                Schema::ROLE        => 'post',
+                Schema::MAPPER      => TimestampedMapper::class,
+                Schema::DATABASE    => 'default',
+                Schema::TABLE       => 'post',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS     => ['id', 'title', 'content', 'last_comment_id', 'created_at', 'updated_at'],
+                Schema::SCHEMA      => [],
+                Schema::RELATIONS   => [
+                    'lastComment' => [
+                        Relation::TYPE   => Relation::REFERS_TO,
+                        Relation::TARGET => Comment::class,
+                        Relation::SCHEMA => [
+                            Relation::CASCADE   => true,
+                            Relation::INNER_KEY => 'last_comment_id',
+                            Relation::OUTER_KEY => 'id',
+                            Relation::NULLABLE  => true
+                        ],
+                    ],
+                    'comments'    => [
+                        Relation::TYPE   => Relation::HAS_MANY,
+                        Relation::TARGET => Comment::class,
+                        Relation::SCHEMA => [
+                            Relation::CASCADE   => true,
+                            Relation::INNER_KEY => 'id',
+                            Relation::OUTER_KEY => 'post_id',
+                        ],
+                    ],
+                ]
+            ],
+        ]));
+    }
+
+    public function testCreate(): void
+    {
+        $u = new User();
+        $u->email = 'test@email.com';
+
+        $p = new Post();
+        $p->title = 'Title';
+        $p->content = 'Hello World';
+
+        $c = new Comment();
+        $c->user = $u;
+        $c->message = 'hello hello';
+
+        $p->addComment($c);
+
+        $this->enableProfiling();
+        $this->captureWriteQueries();
+
+        $tr = new Transaction($this->orm);
+        $tr->persist($p);
+        $tr->run();
+
+        $this->assertNumWrites(4);
+
+        // no changes!
+        $this->captureWriteQueries();
+        $tr = new Transaction($this->orm);
+        $tr->persist($u);
+        $tr->run();
+        $this->assertNumWrites(0);
+
+        $this->orm = $this->orm->withHeap(new Heap());
+        $selector = new Select($this->orm, Post::class);
+        $selector->load('lastComment.user')
+                 ->load('comments.user');
+
+        $p1 = $selector->wherePK(1)->fetchOne();
+
+        $this->assertEquals($p->id, $p1->id);
+        $this->assertEquals($p->lastComment->id, $p1->lastComment->id);
+
+        $this->assertEquals($p->lastComment->user->id, $p1->lastComment->user->id);
+        $this->assertEquals($p->comments[0]->id, $p1->comments[0]->id);
+        $this->assertEquals($p1->id, $p1->comments[0]->post_id);
+    }
+
+    public function testReferenceUpdate(): void
+    {
+        $u1 = new User();
+        $u1->email = 'test@email.com';
+
+        $u2 = new User();
+        $u2->email = 'test2@email.com';
+
+        $p = new Post();
+        $p->title = 'Title';
+        $p->content = 'Hello World';
+
+        $c1 = new Comment();
+        $c1->user = $u1;
+        $c1->message = 'hello hello';
+
+        $c2 = new Comment();
+        $c2->user = $u2;
+        $c2->message = 'hi hi';
+
+        $p->addComment($c1);
+        $p->addComment($c2);
+
+        $this->enableProfiling();
+        $this->captureWriteQueries();
+
+        $tr = new Transaction($this->orm);
+        $tr->persist($p);
+        $tr->run();
+
+        $c3 = new Comment();
+        $c3->user = $u2;
+        $c3->message = 'hello again';
+
+        $p->addComment($c3);
+
+        $tr = new Transaction($this->orm);
+        $tr->persist($p);
+        $tr->run();
+
+        $this->orm = $this->orm->withHeap(new Heap());
+        $selector = new Select($this->orm, Post::class);
+        $selector->load('lastComment.user')
+            ->load('comments.user');
+
+        $p1 = $selector->wherePK(1)->fetchOne();
+
+        $this->assertEquals($p1->lastComment->id, $c3->id);
+
+        $this->assertEquals($p->lastComment->user->id, $p1->lastComment->user->id);
+        $this->assertEquals($p->comments[0]->id, $p1->comments[0]->id);
+        $this->assertEquals($p1->id, $p1->comments[0]->post_id);
+    }
+}

--- a/tests/ORM/Driver/SQLite/CyclicHasManyReferencesTest.php
+++ b/tests/ORM/Driver/SQLite/CyclicHasManyReferencesTest.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Cycle DataMapper ORM
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Driver\SQLite;
+
+class CyclicHasManyReferencesTest extends \Cycle\ORM\Tests\CyclicHasManyReferencesTest
+{
+    public const DRIVER = 'sqlite';
+}

--- a/tests/ORM/Fixtures/CyclicRef/Comment.php
+++ b/tests/ORM/Fixtures/CyclicRef/Comment.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Cycle DataMapper ORM
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Fixtures\CyclicRef;
+
+class Comment
+{
+    public $id;
+    public $post_id;
+
+    public $message;
+
+    /** @var User */
+    public $user;
+
+    public $created_at;
+    public $updated_at;
+}

--- a/tests/ORM/Fixtures/CyclicRef/Post.php
+++ b/tests/ORM/Fixtures/CyclicRef/Post.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Cycle DataMapper ORM
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Fixtures\CyclicRef;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+class Post
+{
+    public $id;
+    public $title;
+    public $content;
+
+    /** @var Comment */
+    public $lastComment;
+
+    /** @var Comment[]|Collection */
+    public $comments;
+
+    public $created_at;
+    public $updated_at;
+
+    public function __construct()
+    {
+        $this->comments = new ArrayCollection();
+    }
+
+    public function addComment(Comment $c): void
+    {
+        $this->lastComment = $c;
+        $this->comments->add($c);
+    }
+}

--- a/tests/ORM/Fixtures/CyclicRef/TimestampedMapper.php
+++ b/tests/ORM/Fixtures/CyclicRef/TimestampedMapper.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Fixtures\CyclicRef;
+
+use Cycle\ORM\Command\ContextCarrierInterface;
+use Cycle\ORM\Command\Database\Insert;
+use Cycle\ORM\Command\Database\Update;
+use Cycle\ORM\Heap\Node;
+use Cycle\ORM\Heap\State;
+use Cycle\ORM\Mapper\Mapper;
+use DateTimeImmutable;
+
+class TimestampedMapper extends Mapper
+{
+    public function queueCreate($entity, Node $node, State $state): ContextCarrierInterface
+    {
+        /** @var Insert $cmd */
+        $cmd = parent::queueCreate($entity, $node, $state);
+
+        $dt = new DateTimeImmutable();
+
+        $state->register('created_at', $dt, true);
+        $cmd->register('created_at', $dt, true);
+
+        $state->register('updated_at', $dt, true);
+        $cmd->register('updated_at', $dt, true);
+
+        return $cmd;
+    }
+
+    public function queueUpdate($entity, Node $node, State $state): ContextCarrierInterface
+    {
+        /** @var Update $cmd */
+        $cmd = parent::queueUpdate($entity, $node, $state);
+
+        $dt = new DateTimeImmutable();
+
+        $state->register('updated_at', $dt, true);
+        $cmd->registerAppendix('updated_at', $dt);
+
+        return $cmd;
+    }
+}

--- a/tests/ORM/Fixtures/CyclicRef/User.php
+++ b/tests/ORM/Fixtures/CyclicRef/User.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Cycle DataMapper ORM
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Fixtures\CyclicRef;
+
+class User
+{
+    public $id;
+    public $email;
+
+    public $created_at;
+    public $updated_at;
+}


### PR DESCRIPTION
This is a test case for reproducing a bug for simple scenarios such as:

1). There's a `Post` with a `RefersTo` relation to the last comment added to the post
2). `HasMany` relation with `Comment`, that has a `User` `BelongsTo`.

Here's an SQL log for a sequence of commands that simply creates a post with two comments for two different users and then adds a third comment:

```
> Begin transaction
> INSERT INTO "post" ("title", "content", "created_at", "updated_at") VALUES ('Title', 'Hello World', '2020-07-15T09:08:32+00:00', '2020-07-15T09:08:32+00:00')
> Insert ID: 1
> INSERT INTO "user" ("email", "created_at", "updated_at") VALUES ('test@email.com', '2020-07-15T09:08:32+00:00', '2020-07-15T09:08:32+00:00')
> Insert ID: 1
> INSERT INTO "comment" ("post_id", "message", "created_at", "updated_at", "user_id") VALUES (1, 'hello hello', '2020-07-15T09:08:32+00:00', '2020-07-15T09:08:32+00:00', 1)
> Insert ID: 1
> INSERT INTO "user" ("email", "created_at", "updated_at") VALUES ('test2@email.com', '2020-07-15T09:08:32+00:00', '2020-07-15T09:08:32+00:00')
> Insert ID: 2
> INSERT INTO "comment" ("post_id", "message", "created_at", "updated_at", "user_id") VALUES (1, 'hi hi', '2020-07-15T09:08:32+00:00', '2020-07-15T09:08:32+00:00', 2)
> Insert ID: 2
> UPDATE "post"
SET "last_comment_id" = 2
WHERE "id" = 1
> Commit transaction
> Begin transaction
> UPDATE "post"
SET "last_comment_id" = NULL
WHERE "id" = 1
> UPDATE "user"
SET "updated_at" = '2020-07-15T09:08:32+00:00'
WHERE "id" = 2
> INSERT INTO "comment" ("post_id", "message", "created_at", "updated_at", "user_id") VALUES (1, 'hello again', '2020-07-15T09:08:32+00:00', '2020-07-15T09:08:32+00:00', 2)
> Insert ID: 3
> Commit transaction
```

As seen from the log, adding third comment resets the last comment link and also for some reason updates `User` relation.