### PR TITLE
Fix incorrect phpdoc union for Repository::select() return value

### DIFF
--- a/src/Select/Repository.php
+++ b/src/Select/Repository.php
@@ -67,7 +67,7 @@ class Repository implements RepositoryInterface
     /**
      * Get selector associated with the repository.
      *
-     * @return Select|iterable
+     * @return Select
      */
     public function select(): Select
     {


### PR DESCRIPTION
select() function doesn't really return `Select or iterable`, it returns `Select that is iterable`.

So in this case:
```
final class Repository extends BaseRepository
{
    public function withVisible(): self
    {
        $r = clone $this;
        $r->select()->where('visible', 'true');

        return $r;
    }
}
```
psalm complains:
```
https://psalm.dev/113: Cannot call method on possible iterable<mixed, mixed> variable
``` 