### PR TITLE
Bump laminas/laminas-hydrator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "doctrine/inflector": "^1.4",
     "doctrine/collections": "^1.5",
     "doctrine/instantiator": "^1.2",
-    "laminas/laminas-hydrator": "^2.4|^3.0"
+    "laminas/laminas-hydrator": "^2.4|^3.0|^4.0"
   },
   "require-dev": {
     "spiral/tokenizer": "^2.7",


### PR DESCRIPTION
When hydrates entity with typed properties without default value, throws this error:

`Typed property App\Module\User\Domain\Entity\Identity::$created_at must not be accessed before initialization`

`vendor\laminas\laminas-hydrator\src\ReflectionHydrator.php` at line 41