### PR TITLE
Add test for #163

### DIFF
--- a/tests/ORM/Driver/MySQL/RenamedPKTest.php
+++ b/tests/ORM/Driver/MySQL/RenamedPKTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Driver\MySQL;
+
+class RenamedPKTest extends \Cycle\ORM\Tests\RenamedPKTest
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/ORM/Driver/Postgres/RenamedPKTest.php
+++ b/tests/ORM/Driver/Postgres/RenamedPKTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Driver\Postgres;
+
+class RenamedPKTest extends \Cycle\ORM\Tests\RenamedPKTest
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/ORM/Driver/SQLServer/RenamedPKTest.php
+++ b/tests/ORM/Driver/SQLServer/RenamedPKTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Driver\SQLServer;
+
+class RenamedPKTest extends \Cycle\ORM\Tests\RenamedPKTest
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/ORM/Driver/SQLite/RenamedPKTest.php
+++ b/tests/ORM/Driver/SQLite/RenamedPKTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Driver\SQLite;
+
+class RenamedPKTest extends \Cycle\ORM\Tests\RenamedPKTest
+{
+    public const DRIVER = 'sqlite';
+}

--- a/tests/ORM/Fixtures/Identity.php
+++ b/tests/ORM/Fixtures/Identity.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Fixtures;
+
+class Identity
+{
+    private $id;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+}

--- a/tests/ORM/RenamedPKTest.php
+++ b/tests/ORM/RenamedPKTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests;
+
+use Cycle\ORM\Heap\Heap;
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\Schema;
+use Cycle\ORM\Select;
+use Cycle\ORM\Tests\Fixtures\Identity;
+use Cycle\ORM\Tests\Traits\TableTrait;
+use Cycle\ORM\Transaction;
+
+abstract class RenamedPKTest extends BaseTest
+{
+    use TableTrait;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->makeTable(
+            'simple_entity',
+            [
+                'identity_id' => 'primary',
+            ]
+        );
+
+        $this->orm = $this->withSchema(
+            new Schema(
+                [
+                    Identity::class => [
+                        Schema::ROLE        => 'simple_entity',
+                        Schema::DATABASE    => 'default',
+                        Schema::TABLE       => 'simple_entity',
+                        Schema::MAPPER      => Mapper::class,
+                        Schema::PRIMARY_KEY => 'id',
+                        Schema::COLUMNS     => [
+                            'id' => 'identity_id',
+                        ],
+                        Schema::TYPECAST    => [
+                            'id' => 'int',
+                        ],
+                        Schema::SCHEMA      => [],
+                        Schema::RELATIONS   => []
+                    ]
+                ]
+            )
+        );
+    }
+
+    public function testCreateEmpty(): void
+    {
+        $u = new Identity();
+
+        (new Transaction($this->orm))->persist($u)->run();
+
+        $this->assertIsInt($u->getId());
+    }
+
+    public function testCreateWithPredefinedId(): void
+    {
+        $u = new Identity();
+        $u->setId(1);
+
+        (new Transaction($this->orm))->persist($u)->run();
+
+        $s = new Select($this->orm->withHeap(new Heap()), Identity::class);
+        $data = $s->fetchData();
+
+        $this->assertIsInt(current($data)['id']);
+        $this->assertIsInt($u->getId());
+    }
+}


### PR DESCRIPTION
Added test case for #163 

Added test case for inserting entity with only one AutoIncrement empty field. Thrown error:
`Spiral\Database\Exception\BuilderException: Insert rowsets must not be empty`