### PR TITLE
Prevent merge nodes with same roles when initializing pivot entity in ManyToMany relation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 vendor/
 *.db
 clover.xml
+docker-compose.override.yml

--- a/src/Relation/ManyToMany.php
+++ b/src/Relation/ManyToMany.php
@@ -11,12 +11,10 @@ declare(strict_types=1);
 
 namespace Cycle\ORM\Relation;
 
-use Cycle\ORM\Command\Branch\Nil;
 use Cycle\ORM\Command\Branch\Sequence;
 use Cycle\ORM\Command\CommandInterface;
 use Cycle\ORM\Command\ContextCarrierInterface as CC;
 use Cycle\ORM\Heap\Node;
-use Cycle\ORM\Heap\State;
 use Cycle\ORM\Iterator;
 use Cycle\ORM\ORMInterface;
 use Cycle\ORM\Promise\Collection\CollectionPromiseInterface;
@@ -27,14 +25,14 @@ use Doctrine\Common\Collections\Collection;
 
 class ManyToMany extends Relation\AbstractRelation
 {
-
     /** @var string */
     protected $throughInnerKey;
 
     /** @var string */
     protected $throughOuterKey;
+
     /** @var string|null */
-    private $pivotEntity;
+    protected $pivotEntity;
 
     /**
      * @param ORMInterface $orm
@@ -232,14 +230,15 @@ class ManyToMany extends Relation\AbstractRelation
      *
      * @param Node $node
      * @param Node $related
-     * @return array<Node, Node>
+     * @return Node[]
      */
-    private function sortRelation(Node $node, Node $related): array
+    protected function sortRelation(Node $node, Node $related): array
     {
         // always use single storage
-        $list = [$node->getRole() => $node, $related->getRole() => $related];
-        ksort($list);
+        if ($related->getState()->getStorage($this->pivotEntity)->contains($node)) {
+            return [$related, $node];
+        }
 
-        return array_values($list);
+        return [$node, $related];
     }
 }

--- a/tests/ORM/Driver/MySQL/ManyToManySingleEntityTest.php
+++ b/tests/ORM/Driver/MySQL/ManyToManySingleEntityTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Driver\MySQL;
+
+final class ManyToManySingleEntityTest extends \Cycle\ORM\Tests\ManyToManySingleEntityTest
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/ORM/Driver/Postgres/ManyToManySingleEntityTest.php
+++ b/tests/ORM/Driver/Postgres/ManyToManySingleEntityTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Driver\Postgres;
+
+final class ManyToManySingleEntityTest extends \Cycle\ORM\Tests\ManyToManySingleEntityTest
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/ORM/Driver/SQLServer/ManyToManySingleEntityTest.php
+++ b/tests/ORM/Driver/SQLServer/ManyToManySingleEntityTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Driver\SQLServer;
+
+final class ManyToManySingleEntityTest extends \Cycle\ORM\Tests\ManyToManySingleEntityTest
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/ORM/Driver/SQLite/ManyToManySingleEntityTest.php
+++ b/tests/ORM/Driver/SQLite/ManyToManySingleEntityTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Driver\SQLite;
+
+final class ManyToManySingleEntityTest extends \Cycle\ORM\Tests\ManyToManySingleEntityTest
+{
+    public const DRIVER = 'sqlite';
+}

--- a/tests/ORM/Fixtures/RbacItemAbstract.php
+++ b/tests/ORM/Fixtures/RbacItemAbstract.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Fixtures;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection as DoctrineCollection;
+
+class RbacItemAbstract
+{
+    /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @var DoctrineCollection|RbacRole[]|RbacPermission[]
+     * @phpstan-var DoctrineCollection<string,RbacRole|RbacPermission>
+     */
+    public $parents;
+
+    /**
+     * @var DoctrineCollection|RbacRole[]|RbacPermission[]
+     * @phpstan-var DoctrineCollection<string,RbacRole|RbacPermission>
+     */
+    public $children;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+
+        $this->parents = new ArrayCollection();
+        $this->children = new ArrayCollection();
+    }
+}

--- a/tests/ORM/Fixtures/RbacPermission.php
+++ b/tests/ORM/Fixtures/RbacPermission.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Fixtures;
+
+final class RbacPermission extends RbacItemAbstract
+{
+
+}

--- a/tests/ORM/Fixtures/RbacRole.php
+++ b/tests/ORM/Fixtures/RbacRole.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Fixtures;
+
+final class RbacRole extends RbacItemAbstract
+{
+
+}

--- a/tests/ORM/ManyToManySingleEntityTest.php
+++ b/tests/ORM/ManyToManySingleEntityTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests;
+
+use Cycle\ORM\Heap\Heap;
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\Mapper\StdMapper;
+use Cycle\ORM\Relation;
+use Cycle\ORM\Schema;
+use Cycle\ORM\Select;
+use Cycle\ORM\Tests\Fixtures\RbacItemAbstract;
+use Cycle\ORM\Tests\Fixtures\RbacPermission;
+use Cycle\ORM\Tests\Fixtures\RbacRole;
+use Cycle\ORM\Tests\Traits\TableTrait;
+use Cycle\ORM\Transaction;
+
+abstract class ManyToManySingleEntityTest extends BaseTest
+{
+    use TableTrait;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->makeTable('rbac_item', [
+            'name' => 'string,primary',
+            '_type' => 'string,nullable',
+        ]);
+
+        $this->makeTable('rbac_item_inheritance', [
+            'id' => 'primary',
+            'parent' => 'string',
+            'child' => 'string',
+        ]);
+
+        $this->makeFK('rbac_item_inheritance', 'parent', 'rbac_item', 'name', 'NO ACTION', 'NO ACTION');
+        $this->makeFK('rbac_item_inheritance', 'child', 'rbac_item', 'name', 'NO ACTION', 'NO ACTION');
+
+        $this->withSchema(new Schema([
+            RbacItemAbstract::class => [
+                Schema::ROLE => 'rbac_item',
+                Schema::CHILDREN => [
+                    'role' => RbacRole::class,
+                    'permission' => RbacPermission::class,
+                ],
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'rbac_item',
+                Schema::PRIMARY_KEY => 'name',
+                Schema::COLUMNS => ['name', '_type'],
+                Schema::RELATIONS => [
+                    'parents' => [
+                        Relation::TYPE => Relation::MANY_TO_MANY,
+                        Relation::TARGET => 'rbac_item',
+                        Relation::SCHEMA => [
+                            Relation::CASCADE => true,
+                            Relation::THROUGH_ENTITY => 'rbac_item_inheritance',
+                            Relation::INNER_KEY => 'name',
+                            Relation::OUTER_KEY => 'name',
+                            Relation::THROUGH_INNER_KEY => 'child',
+                            Relation::THROUGH_OUTER_KEY => 'parent',
+                        ],
+                    ],
+                    'children' => [
+                        Relation::TYPE => Relation::MANY_TO_MANY,
+                        Relation::TARGET => 'rbac_item',
+                        Relation::SCHEMA => [
+                            Relation::CASCADE => true,
+                            Relation::THROUGH_ENTITY => 'rbac_item_inheritance',
+                            Relation::INNER_KEY => 'name',
+                            Relation::OUTER_KEY => 'name',
+                            Relation::THROUGH_INNER_KEY => 'parent',
+                            Relation::THROUGH_OUTER_KEY => 'child',
+                        ],
+                    ],
+                ],
+            ],
+            RbacRole::class => [
+                Schema::ROLE => RbacItemAbstract::class,
+            ],
+            RbacPermission::class => [
+                Schema::ROLE => RbacItemAbstract::class,
+            ],
+            'rbac_item_inheritance' => [
+                Schema::ROLE => 'rbac_item_inheritance',
+                Schema::MAPPER => StdMapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'rbac_item_inheritance',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'parent', 'child'],
+                Schema::RELATIONS => [],
+            ],
+        ]));
+    }
+
+    public function testStore(): void
+    {
+        $role = new RbacRole('superAdmin');
+
+        $permission = new RbacPermission('writeUser');
+
+        $role->children->add($permission);
+        $permission->parents->add($role);
+
+        $tr = new Transaction($this->orm);
+        $tr->persist($role);
+        $tr->run();
+
+        $selector = new Select($this->orm->withHeap(new Heap()), 'rbac_item');
+        /** @var RbacRole $fetchedRole */
+        $fetchedRole = $selector->wherePK('superAdmin')->fetchOne();
+
+        self::assertInstanceOf(RbacRole::class, $fetchedRole);
+        self::assertCount(1, $fetchedRole->children);
+        self::assertInstanceOf(RbacPermission::class, $fetchedRole->children->first());
+        self::assertSame('writeUser', $fetchedRole->children->first()->name);
+    }
+}


### PR DESCRIPTION
Текущие тесты не сломались. Нужна помощь с описанием теста под кейс из issue.

Closes #171 