### PR TITLE
refactor: rename constrain to scope

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -15,9 +15,9 @@ use Cycle\ORM\Config\RelationConfig;
 use Cycle\ORM\Exception\TypecastException;
 use Cycle\ORM\Mapper\Mapper;
 use Cycle\ORM\Relation\RelationInterface;
-use Cycle\ORM\Select\ConstrainInterface;
 use Cycle\ORM\Select\LoaderInterface;
 use Cycle\ORM\Select\Repository;
+use Cycle\ORM\Select\ScopeInterface;
 use Cycle\ORM\Select\Source;
 use Cycle\ORM\Select\SourceInterface;
 use Spiral\Core\Container;
@@ -39,9 +39,9 @@ final class Factory implements FactoryInterface
     /** @var array<string, string> */
     private $defaults = [
         Schema::REPOSITORY => Repository::class,
-        Schema::SOURCE     => Source::class,
-        Schema::MAPPER     => Mapper::class,
-        Schema::CONSTRAIN  => null,
+        Schema::SOURCE => Source::class,
+        Schema::MAPPER => Mapper::class,
+        Schema::SCOPE => null,
     ];
 
     /**
@@ -86,8 +86,8 @@ final class Factory implements FactoryInterface
         return $this->factory->make(
             $class,
             [
-                'orm'    => $orm,
-                'role'   => $role,
+                'orm' => $orm,
+                'role' => $role,
                 'schema' => $schema->define($role, Schema::SCHEMA)
             ]
         );
@@ -107,8 +107,8 @@ final class Factory implements FactoryInterface
         return $this->config->getLoader($schema[Relation::TYPE])->resolve(
             $this->factory,
             [
-                'orm'    => $orm,
-                'name'   => $relation,
+                'orm' => $orm,
+                'name' => $relation,
                 'target' => $schema[Relation::TARGET],
                 'schema' => $schema[Relation::SCHEMA]
             ]
@@ -130,8 +130,8 @@ final class Factory implements FactoryInterface
         return $this->config->getRelation($type)->resolve(
             $this->factory,
             [
-                'orm'    => $orm,
-                'name'   => $relation,
+                'orm' => $orm,
+                'name' => $relation,
                 'target' => $relSchema[Relation::TARGET],
                 'schema' => $relSchema[Relation::SCHEMA] + [Relation::LOAD => $relSchema[Relation::LOAD] ?? null],
             ]
@@ -165,8 +165,8 @@ final class Factory implements FactoryInterface
             $class,
             [
                 'select' => $select,
-                'orm'    => $orm,
-                'role'   => $role,
+                'orm' => $orm,
+                'role' => $role,
             ]
         );
     }
@@ -194,17 +194,17 @@ final class Factory implements FactoryInterface
             $schema->define($role, Schema::TABLE)
         );
 
-        $constrain = $schema->define($role, Schema::CONSTRAIN) ?? $this->defaults[Schema::CONSTRAIN];
+        $scope = $schema->define($role, Schema::SCOPE) ?? $this->defaults[Schema::SCOPE];
 
-        if ($constrain === null) {
+        if ($scope === null) {
             return $source;
         }
 
-        if (!is_subclass_of($constrain, ConstrainInterface::class)) {
-            throw new TypecastException($constrain . ' does not implement ' . ConstrainInterface::class);
+        if (!is_subclass_of($scope, ScopeInterface::class)) {
+            throw new TypecastException($scope . ' does not implement ' . ScopeInterface::class);
         }
 
-        return $source->withConstrain(is_object($constrain) ? $constrain : $this->factory->make($constrain));
+        return $source->withScope(is_object($scope) ? $scope : $this->factory->make($scope));
     }
 
     /**

--- a/src/ORM.php
+++ b/src/ORM.php
@@ -265,7 +265,7 @@ final class ORM implements ORMInterface
 
         if ($this->schema->define($role, Schema::TABLE) !== null) {
             $select = new Select($this, $role);
-            $select->constrain($this->getSource($role)->getConstrain());
+            $select->scope($this->getSource($role)->getScope());
         }
 
         return $this->repositories[$role] = $this->factory->repository($this, $this->schema, $role, $select);

--- a/src/Relation/Pivoted/PivotedPromise.php
+++ b/src/Relation/Pivoted/PivotedPromise.php
@@ -44,9 +44,9 @@ final class PivotedPromise implements PromiseInterface
 
     /**
      * @param ORMInterface $orm
-     * @param string       $target
-     * @param array        $relationSchema
-     * @param mixed        $innerKey
+     * @param string $target
+     * @param array $relationSchema
+     * @param mixed $innerKey
      */
     public function __construct(ORMInterface $orm, string $target, array $relationSchema, $innerKey)
     {
@@ -113,9 +113,9 @@ final class PivotedPromise implements PromiseInterface
 
         /** @var ManyToManyLoader $loader */
         $loader = $loader->withContext($loader, [
-            'constrain' => $this->orm->getSource($this->target)->getConstrain(),
-            'as'        => $this->target,
-            'method'    => JoinableLoader::POSTLOAD
+            'scope' => $this->orm->getSource($this->target)->getScope(),
+            'as' => $this->target,
+            'method' => JoinableLoader::POSTLOAD
         ]);
 
         $query = $loader->configureQuery($query, [$this->innerKey]);

--- a/src/SchemaInterface.php
+++ b/src/SchemaInterface.php
@@ -18,21 +18,26 @@ interface SchemaInterface
     /*
      * Various segments of schema.
      */
-    public const ROLE         = 0;
-    public const ENTITY       = 1;
-    public const MAPPER       = 2;
-    public const SOURCE       = 3;
-    public const REPOSITORY   = 4;
-    public const DATABASE     = 5;
-    public const TABLE        = 6;
-    public const PRIMARY_KEY  = 7;
+    public const ROLE = 0;
+    public const ENTITY = 1;
+    public const MAPPER = 2;
+    public const SOURCE = 3;
+    public const REPOSITORY = 4;
+    public const DATABASE = 5;
+    public const TABLE = 6;
+    public const PRIMARY_KEY = 7;
     public const FIND_BY_KEYS = 8;
-    public const COLUMNS      = 9;
-    public const RELATIONS    = 10;
-    public const CHILDREN     = 11;
-    public const CONSTRAIN    = 12;
-    public const TYPECAST     = 13;
-    public const SCHEMA       = 14;
+    public const COLUMNS = 9;
+    public const RELATIONS = 10;
+    public const CHILDREN = 11;
+    public const SCOPE = 12;
+    public const TYPECAST = 13;
+    public const SCHEMA = 14;
+
+    /**
+     * @deprecated use {@see SchemaInterface::SCOPE} instead
+     */
+    public const CONSTRAIN = self::SCOPE;
 
     /**
      * Return all roles defined within the schema.
@@ -63,7 +68,7 @@ interface SchemaInterface
      * Example: $schema->define(User::class, SchemaInterface::DATABASE);
      *
      * @param string $role
-     * @param int    $property See ORM constants.
+     * @param int $property See ORM constants.
      * @return mixed
      *
      * @throws SchemaException

--- a/src/Select.php
+++ b/src/Select.php
@@ -17,6 +17,7 @@ use Cycle\ORM\Select\ConstrainInterface;
 use Cycle\ORM\Select\JoinableLoader;
 use Cycle\ORM\Select\QueryBuilder;
 use Cycle\ORM\Select\RootLoader;
+use Cycle\ORM\Select\ScopeInterface;
 use IteratorAggregate;
 use Spiral\Database\Query\SelectQuery;
 use Spiral\Pagination\PaginableInterface;
@@ -114,16 +115,26 @@ final class Select implements IteratorAggregate, Countable, PaginableInterface
     }
 
     /**
-     * Create new Selector with applied scope. By default no constrain used.
+     * Create new Selector with applied scope. By default no scope used.
      *
+     * @param ScopeInterface|null $scope
+     * @return Select
+     */
+    public function scope(?ScopeInterface $scope): self
+    {
+        $this->loader->setScope($scope);
+
+        return $this;
+    }
+
+    /**
+     * @deprecated Will be dropped in next major release. Use {@see scope()} instead.
      * @param ConstrainInterface|null $constrain
      * @return Select
      */
-    public function constrain(ConstrainInterface $constrain = null): self
+    public function constrain(?ConstrainInterface $constrain = null): self
     {
-        $this->loader->setConstrain($constrain);
-
-        return $this;
+        return $this->scope($constrain);
     }
 
     /**

--- a/src/Select/ConstrainInterface.php
+++ b/src/Select/ConstrainInterface.php
@@ -11,15 +11,15 @@ declare(strict_types=1);
 
 namespace Cycle\ORM\Select;
 
-/**
- * Provides the ability to modify the selector and/or entity loader. Can be used to implement multi-table inheritance.
- */
-interface ConstrainInterface
-{
+use function class_alias;
+
+class_alias(ScopeInterface::class, __NAMESPACE__ . '\ConstrainInterface');
+
+if (false) {
     /**
-     * Configure query and loader pair using proxy strategy.
-     *
-     * @param QueryBuilder $query
+     * @deprecated Use {@see ScopeInterface} instead.
      */
-    public function apply(QueryBuilder $query);
+    interface ConstrainInterface extends ScopeInterface
+    {
+    }
 }

--- a/src/Select/Loader/BelongsToLoader.php
+++ b/src/Select/Loader/BelongsToLoader.php
@@ -34,13 +34,13 @@ class BelongsToLoader extends JoinableLoader
      * @var array
      */
     protected $options = [
-        'load'      => false,
-        'constrain' => true,
-        'method'    => self::POSTLOAD,
-        'minify'    => true,
-        'as'        => null,
-        'using'     => null,
-        'where'     => null,
+        'load' => false,
+        'scope' => true,
+        'method' => self::POSTLOAD,
+        'minify' => true,
+        'as' => null,
+        'using' => null,
+        'where' => null,
     ];
 
     /**

--- a/src/Select/Loader/HasManyLoader.php
+++ b/src/Select/Loader/HasManyLoader.php
@@ -35,14 +35,14 @@ class HasManyLoader extends JoinableLoader
      * @var array
      */
     protected $options = [
-        'load'      => false,
-        'constrain' => true,
-        'method'    => self::POSTLOAD,
-        'minify'    => true,
-        'as'        => null,
-        'using'     => null,
-        'where'     => null,
-        'orderBy'   => null,
+        'load' => false,
+        'scope' => true,
+        'method' => self::POSTLOAD,
+        'minify' => true,
+        'as' => null,
+        'using' => null,
+        'where' => null,
+        'orderBy' => null,
     ];
 
     /**
@@ -60,7 +60,7 @@ class HasManyLoader extends JoinableLoader
      */
     public function configureQuery(SelectQuery $query, array $outerKeys = []): SelectQuery
     {
-        if ($this->isLoaded() && $this->isJoined() && (int) $query->getLimit() !== 0) {
+        if ($this->isLoaded() && $this->isJoined() && (int)$query->getLimit() !== 0) {
             throw new LoaderException('Unable to load data using join with limit on parent query');
         }
 

--- a/src/Select/Loader/HasOneLoader.php
+++ b/src/Select/Loader/HasOneLoader.php
@@ -38,13 +38,13 @@ class HasOneLoader extends JoinableLoader
      * @var array
      */
     protected $options = [
-        'load'      => false,
-        'constrain' => true,
-        'method'    => self::INLOAD,
-        'minify'    => true,
-        'as'        => null,
-        'using'     => null,
-        'where'     => null
+        'load' => false,
+        'scope' => true,
+        'method' => self::INLOAD,
+        'minify' => true,
+        'as' => null,
+        'using' => null,
+        'where' => null
     ];
 
     /**

--- a/src/Select/Loader/ManyToManyLoader.php
+++ b/src/Select/Loader/ManyToManyLoader.php
@@ -24,7 +24,6 @@ use Cycle\ORM\Select\Traits\OrderByTrait;
 use Cycle\ORM\Select\Traits\WhereTrait;
 use Spiral\Database\Injection\Parameter;
 use Spiral\Database\Query\SelectQuery;
-use Spiral\Database\StatementInterface;
 
 class ManyToManyLoader extends JoinableLoader
 {
@@ -37,15 +36,15 @@ class ManyToManyLoader extends JoinableLoader
      * @var array
      */
     protected $options = [
-        'load'      => false,
-        'constrain' => true,
-        'method'    => self::POSTLOAD,
-        'minify'    => true,
-        'as'        => null,
-        'using'     => null,
-        'where'     => null,
-        'orderBy'   => null,
-        'pivot'     => null,
+        'load' => false,
+        'scope' => true,
+        'method' => self::POSTLOAD,
+        'minify' => true,
+        'as' => null,
+        'using' => null,
+        'where' => null,
+        'orderBy' => null,
+        'pivot' => null,
     ];
 
     /** @var PivotLoader */
@@ -73,17 +72,19 @@ class ManyToManyLoader extends JoinableLoader
 
     /**
      * @param LoaderInterface $parent
-     * @param array           $options
+     * @param array $options
      * @return LoaderInterface
      */
     public function withContext(LoaderInterface $parent, array $options = []): LoaderInterface
     {
+        $options = $this->prepareOptions($options);
+
         /** @var ManyToManyLoader $loader */
         $loader = parent::withContext($parent, $options);
         $loader->pivot = $loader->pivot->withContext(
             $loader,
             [
-                'load'   => $loader->isLoaded(),
+                'load' => $loader->isLoaded(),
                 'method' => $options['method'] ?? self::JOIN,
             ] + ($options['pivot'] ?? [])
         );
@@ -93,9 +94,9 @@ class ManyToManyLoader extends JoinableLoader
 
     /**
      * @param string $relation
-     * @param array  $options
-     * @param bool   $join
-     * @param bool   $load
+     * @param array $options
+     * @param bool $join
+     * @param bool $load
      * @return LoaderInterface
      */
     public function loadRelation(
@@ -122,7 +123,7 @@ class ManyToManyLoader extends JoinableLoader
      */
     public function configureQuery(SelectQuery $query, array $outerKeys = []): SelectQuery
     {
-        if ($this->isLoaded() && $this->isJoined() && (int) $query->getLimit() !== 0) {
+        if ($this->isLoaded() && $this->isJoined() && (int)$query->getLimit() !== 0) {
             throw new LoaderException('Unable to load data using join with limit on parent query');
         }
 

--- a/src/Select/Loader/PivotLoader.php
+++ b/src/Select/Loader/PivotLoader.php
@@ -33,12 +33,12 @@ class PivotLoader extends JoinableLoader
      * @var array
      */
     protected $options = [
-        'load'      => false,
-        'constrain' => true,
-        'method'    => self::JOIN,
-        'minify'    => true,
-        'as'        => null,
-        'using'     => null
+        'load' => false,
+        'scope' => true,
+        'method' => self::JOIN,
+        'minify' => true,
+        'as' => null,
+        'using' => null
     ];
 
     /**

--- a/src/Select/QueryBuilder.php
+++ b/src/Select/QueryBuilder.php
@@ -151,7 +151,7 @@ final class QueryBuilder
         $loader = $this->findLoader(substr($identifier, 0, $split), $autoload);
         if ($loader !== null) {
             return sprintf(
-                '%s.%s.',
+                '%s.%s',
                 $loader->getAlias(),
                 $loader->fieldAlias(substr($identifier, $split + 1))
             );

--- a/src/Select/QueryConstrain.php
+++ b/src/Select/QueryConstrain.php
@@ -1,42 +1,18 @@
 <?php
 
-/**
- * Cycle DataMapper ORM
- *
- * @license   MIT
- * @author    Anton Titov (Wolfy-J)
- */
-
 declare(strict_types=1);
 
 namespace Cycle\ORM\Select;
 
-/**
- * Provides the ability to scope query and load necessary relations into the loader.
- */
-final class QueryConstrain implements ConstrainInterface
-{
-    /** @var array */
-    private $where = [];
+use function class_alias;
 
-    /** @var array */
-    private $orderBy = [];
+class_alias(Scope\QueryScope::class, __NAMESPACE__ . '\QueryConstrain');
 
+if (false) {
     /**
-     * @param array $where
-     * @param array $orderBy
+     * @deprecated Use {@see Scope\QueryScope} instead.
      */
-    public function __construct(array $where, array $orderBy = [])
+    class QueryConstrain extends Scope\QueryScope
     {
-        $this->where = $where;
-        $this->orderBy = $orderBy;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function apply(QueryBuilder $query): void
-    {
-        $query->where($this->where)->orderBy($this->orderBy);
     }
 }

--- a/src/Select/RootLoader.php
+++ b/src/Select/RootLoader.php
@@ -17,7 +17,6 @@ use Cycle\ORM\Parser\RootNode;
 use Cycle\ORM\Parser\Typecast;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select\Traits\ColumnsTrait;
-use Cycle\ORM\Select\Traits\ConstrainTrait;
 use Spiral\Database\Query\SelectQuery;
 use Spiral\Database\StatementInterface;
 
@@ -30,12 +29,11 @@ use Spiral\Database\StatementInterface;
 final class RootLoader extends AbstractLoader
 {
     use ColumnsTrait;
-    use ConstrainTrait;
 
     /** @var array */
     protected $options = [
-        'load'      => true,
-        'constrain' => true,
+        'load' => true,
+        'scope' => true,
     ];
 
     /** @var SelectQuery */
@@ -43,7 +41,7 @@ final class RootLoader extends AbstractLoader
 
     /**
      * @param ORMInterface $orm
-     * @param string       $target
+     * @param string $target
      */
     public function __construct(ORMInterface $orm, string $target)
     {

--- a/src/Select/Scope/QueryScope.php
+++ b/src/Select/Scope/QueryScope.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Cycle DataMapper ORM
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Select\Scope;
+
+use Cycle\ORM\Select\QueryBuilder;
+use Cycle\ORM\Select\ScopeInterface;
+
+/**
+ * Provides the ability to scope query and load necessary relations into the loader.
+ * @final
+ */
+class QueryScope implements ScopeInterface
+{
+    /** @var array */
+    private $where;
+
+    /** @var array */
+    private $orderBy;
+
+    /**
+     * @param array $where
+     * @param array $orderBy
+     */
+    public function __construct(array $where, array $orderBy = [])
+    {
+        $this->where = $where;
+        $this->orderBy = $orderBy;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function apply(QueryBuilder $query): void
+    {
+        $query->where($this->where)->orderBy($this->orderBy);
+    }
+}

--- a/src/Select/ScopeInterface.php
+++ b/src/Select/ScopeInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Cycle DataMapper ORM
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Select;
+
+/**
+ * Provides the ability to modify the selector and/or entity loader. Can be used to implement multi-table inheritance.
+ */
+interface ScopeInterface
+{
+    /**
+     * Configure query and loader pair using proxy strategy.
+     *
+     * @param QueryBuilder $query
+     */
+    public function apply(QueryBuilder $query);
+}

--- a/src/Select/Source.php
+++ b/src/Select/Source.php
@@ -21,12 +21,12 @@ final class Source implements SourceInterface
     /** @var string */
     private $table;
 
-    /** @var ConstrainInterface|null */
-    private $constrain = null;
+    /** @var ScopeInterface|null */
+    private $scope = null;
 
     /**
      * @param DatabaseInterface $database
-     * @param string            $table
+     * @param string $table
      */
     public function __construct(DatabaseInterface $database, string $table)
     {
@@ -53,10 +53,10 @@ final class Source implements SourceInterface
     /**
      * @inheritdoc
      */
-    public function withConstrain(?ConstrainInterface $constrain): SourceInterface
+    public function withScope(?ScopeInterface $scope): SourceInterface
     {
         $source = clone $this;
-        $source->constrain = $constrain;
+        $source->scope = $scope;
 
         return $source;
     }
@@ -64,8 +64,26 @@ final class Source implements SourceInterface
     /**
      * @inheritdoc
      */
+    public function getScope(): ?ScopeInterface
+    {
+        return $this->scope;
+    }
+
+    /**
+     * @inheritdoc
+     * @deprecated Use {@see withScope()} instead.
+     */
+    public function withConstrain(?ConstrainInterface $constrain): SourceInterface
+    {
+        return $this->withScope($constrain);
+    }
+
+    /**
+     * @inheritdoc
+     * @deprecated Use {@see getScope()} instead.
+     */
     public function getConstrain(): ?ConstrainInterface
     {
-        return $this->constrain;
+        return $this->getScope();
     }
 }

--- a/src/Select/SourceInterface.php
+++ b/src/Select/SourceInterface.php
@@ -35,14 +35,27 @@ interface SourceInterface
     /**
      * Associate query constrain (or remove association).
      *
+     * @param ScopeInterface|null $scope
+     * @return SourceInterface
+     */
+    public function withScope(?ScopeInterface $scope): SourceInterface;
+
+    /**
+     * Return associated query constrain.
+     *
+     * @return ScopeInterface|null
+     */
+    public function getScope(): ?ScopeInterface;
+
+    /**
+     * @deprecated Use {@see withScope()} instead.
      * @param ConstrainInterface|null $constrain
      * @return SourceInterface
      */
     public function withConstrain(?ConstrainInterface $constrain): SourceInterface;
 
     /**
-     * Return associated query constrain.
-     *
+     * @deprecated Use {@see getScope()} instead.
      * @return ConstrainInterface|null
      */
     public function getConstrain(): ?ConstrainInterface;

--- a/src/Select/Traits/ConstrainTrait.php
+++ b/src/Select/Traits/ConstrainTrait.php
@@ -11,47 +11,18 @@ declare(strict_types=1);
 
 namespace Cycle\ORM\Select\Traits;
 
-use Cycle\ORM\Select\AbstractLoader;
-use Cycle\ORM\Select\ConstrainInterface;
-use Cycle\ORM\Select\QueryBuilder;
-use Spiral\Database\Query\SelectQuery;
+class_alias(
+    ScopeTrait::class,
+    __NAMESPACE__ . '\ConstrainTrait'
+);
 
-/**
- * Provides the ability to assign the scope to the AbstractLoader.
- */
-trait ConstrainTrait
-{
-    /** @var null|ConstrainInterface */
-    protected $constrain;
 
+if (false) {
     /**
-     * Associate scope with the selector.
-     *
-     * @param ConstrainInterface $constrain
-     * @return AbstractLoader|$this
+     * @deprecated Use {@see ScopeTrait} instead.
      */
-    public function setConstrain(ConstrainInterface $constrain = null): self
+    trait ConstrainTrait
     {
-        $this->constrain = $constrain;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    abstract public function getAlias(): string;
-
-    /**
-     * @param SelectQuery $query
-     * @return SelectQuery
-     */
-    protected function applyConstrain(SelectQuery $query): SelectQuery
-    {
-        if ($this->constrain !== null) {
-            $this->constrain->apply(new QueryBuilder($query, $this));
-        }
-
-        return $query;
+        use ScopeTrait;
     }
 }

--- a/src/Select/Traits/ScopeTrait.php
+++ b/src/Select/Traits/ScopeTrait.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Cycle DataMapper ORM
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Select\Traits;
+
+use Cycle\ORM\Select\AbstractLoader;
+use Cycle\ORM\Select\ConstrainInterface;
+use Cycle\ORM\Select\QueryBuilder;
+use Cycle\ORM\Select\ScopeInterface;
+use Spiral\Database\Query\SelectQuery;
+
+/**
+ * Provides the ability to assign the scope to the AbstractLoader.
+ */
+trait ScopeTrait
+{
+    /** @var null|ScopeInterface */
+    protected $scope;
+
+    public function getScope(): ?ScopeInterface
+    {
+        return $this->scope;
+    }
+
+    /**
+     * Associate scope with the selector.
+     * @param ScopeInterface|null $scope
+     */
+    public function setScope(?ScopeInterface $scope): void
+    {
+        $this->scope = $scope;
+    }
+
+    /**
+     * @deprecated Use {@see setScope()} instead.
+     * @param ConstrainInterface|null $constrain
+     * @return AbstractLoader|$this
+     */
+    public function setConstrain(?ConstrainInterface $constrain = null): self
+    {
+        $this->setScope($constrain);
+
+        return $this;
+    }
+
+    /**
+     * @param SelectQuery $query
+     * @return SelectQuery
+     */
+    protected function applyScope(SelectQuery $query): SelectQuery
+    {
+        if ($this->scope !== null) {
+            $this->scope->apply(new QueryBuilder($query, $this));
+        }
+
+        return $query;
+    }
+}

--- a/tests/ORM/Classless/ClasslessHasManyPromiseTest.php
+++ b/tests/ORM/Classless/ClasslessHasManyPromiseTest.php
@@ -19,7 +19,7 @@ use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
 use Cycle\ORM\Tests\BaseTest;
-use Cycle\ORM\Tests\Fixtures\SortByIDConstrain;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
 use Cycle\ORM\Tests\Traits\TableTrait;
 use Cycle\ORM\Transaction;
 
@@ -90,7 +90,7 @@ abstract class ClasslessHasManyPromiseTest extends BaseTest
                 Schema::COLUMNS     => ['id', 'user_id', 'message'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ]
         ]));
     }

--- a/tests/ORM/Classless/ClasslessInverseRelationTest.php
+++ b/tests/ORM/Classless/ClasslessInverseRelationTest.php
@@ -17,7 +17,7 @@ use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
 use Cycle\ORM\Tests\BaseTest;
-use Cycle\ORM\Tests\Fixtures\SortByIDConstrain;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
 use Cycle\ORM\Tests\Traits\TableTrait;
 use Cycle\ORM\Transaction;
 
@@ -79,7 +79,7 @@ abstract class ClasslessInverseRelationTest extends BaseTest
                         ],
                     ]
                 ],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ],
             'profile' => [
                 Schema::MAPPER      => StdMapper::class,
@@ -99,7 +99,7 @@ abstract class ClasslessInverseRelationTest extends BaseTest
                         ],
                     ],
                 ],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ],
         ]));
     }

--- a/tests/ORM/Driver/Postgres/SequenceDefaultValueTest.php
+++ b/tests/ORM/Driver/Postgres/SequenceDefaultValueTest.php
@@ -8,7 +8,7 @@ use Cycle\ORM\Heap\Heap;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
 use Cycle\ORM\Tests\BaseTest;
-use Cycle\ORM\Tests\Fixtures\NotDeletedConstrain;
+use Cycle\ORM\Tests\Fixtures\NotDeletedScope;
 use Cycle\ORM\Tests\Fixtures\SequenceDefaultValueMapper;
 use Cycle\ORM\Tests\Fixtures\User;
 use Cycle\ORM\Tests\Traits\TableTrait;
@@ -56,7 +56,7 @@ class SequenceDefaultValueTest extends BaseTest
                         ],
                         Schema::SCHEMA => [],
                         Schema::RELATIONS => [],
-                        Schema::CONSTRAIN => NotDeletedConstrain::class
+                        Schema::SCOPE => NotDeletedScope::class
                     ]
                 ]
             )

--- a/tests/ORM/EmbeddedLoaderTest.php
+++ b/tests/ORM/EmbeddedLoaderTest.php
@@ -16,7 +16,7 @@ use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
 use Cycle\ORM\Tests\Fixtures\Comment;
-use Cycle\ORM\Tests\Fixtures\SortByIDConstrain;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
 use Cycle\ORM\Tests\Fixtures\User;
 use Cycle\ORM\Tests\Fixtures\UserCredentials;
 use Cycle\ORM\Tests\Traits\TableTrait;
@@ -114,7 +114,7 @@ abstract class EmbeddedLoaderTest extends BaseTest
                 Schema::COLUMNS     => ['id', 'user_id', 'message'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ]
         ]));
     }

--- a/tests/ORM/Fixtures/DifferentSource.php
+++ b/tests/ORM/Fixtures/DifferentSource.php
@@ -5,25 +5,40 @@ declare(strict_types=1);
 namespace Cycle\ORM\Tests\Fixtures;
 
 use Cycle\ORM\Select\ConstrainInterface;
+use Cycle\ORM\Select\ScopeInterface;
 use Cycle\ORM\Select\SourceInterface;
 use Spiral\Database\DatabaseInterface;
 
 class DifferentSource implements SourceInterface
 {
-
     /**
      * @inheritDoc
      */
     public function getDatabase(): DatabaseInterface
     {
-        // TODO: Implement getDatabase() method.
-        return null;
+        throw new \RuntimeException('Not implemented.');
     }
 
     /**
      * @inheritDoc
      */
     public function getTable(): string
+    {
+        throw new \RuntimeException('Not implemented.');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withScope(?ScopeInterface $scope): SourceInterface
+    {
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getScope(): ?ScopeInterface
     {
         return null;
     }

--- a/tests/ORM/Fixtures/LeveledHasManyScope.php
+++ b/tests/ORM/Fixtures/LeveledHasManyScope.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Cycle\ORM\Tests\Fixtures;
 
-use Cycle\ORM\Select\ConstrainInterface;
 use Cycle\ORM\Select\QueryBuilder;
+use Cycle\ORM\Select\ScopeInterface;
 
-class LeveledHasManyConstrain implements ConstrainInterface
+class LeveledHasManyScope implements ScopeInterface
 {
     public function apply(QueryBuilder $query): void
     {

--- a/tests/ORM/Fixtures/NotDeletedScope.php
+++ b/tests/ORM/Fixtures/NotDeletedScope.php
@@ -11,13 +11,13 @@ declare(strict_types=1);
 
 namespace Cycle\ORM\Tests\Fixtures;
 
-use Cycle\ORM\Select\ConstrainInterface;
 use Cycle\ORM\Select\QueryBuilder;
+use Cycle\ORM\Select\ScopeInterface;
 
-class SortByMsgConstrain implements ConstrainInterface
+class NotDeletedScope implements ScopeInterface
 {
     public function apply(QueryBuilder $query): void
     {
-        $query->orderBy('message', 'ASC');
+        $query->where('deleted_at', '=', null);
     }
 }

--- a/tests/ORM/Fixtures/ProfilePromise.php
+++ b/tests/ORM/Fixtures/ProfilePromise.php
@@ -69,9 +69,7 @@ class ProfilePromise extends Profile implements PromiseInterface
     {
         if (!is_null($this->orm)) {
             $select = new Select($this->orm, $this->target);
-            $data = $select->constrain(
-                $this->orm->getSource($this->target)->getConstrain()
-            )->where($this->scope)->fetchData();
+            $data = $select->scope($this->orm->getSource($this->target)->getScope())->where($this->scope)->fetchData();
 
             $this->orm->getMapper($this->target)->hydrate($this, $data[0]);
 

--- a/tests/ORM/Fixtures/ShortLeveledHasManyScope.php
+++ b/tests/ORM/Fixtures/ShortLeveledHasManyScope.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Cycle\ORM\Tests\Fixtures;
 
-use Cycle\ORM\Select\ConstrainInterface;
 use Cycle\ORM\Select\QueryBuilder;
+use Cycle\ORM\Select\ScopeInterface;
 
-class ShortLeveledHasManyConstrain implements ConstrainInterface
+class ShortLeveledHasManyScope implements ScopeInterface
 {
     public function apply(QueryBuilder $query): void
     {

--- a/tests/ORM/Fixtures/SortByIDScope.php
+++ b/tests/ORM/Fixtures/SortByIDScope.php
@@ -11,13 +11,13 @@ declare(strict_types=1);
 
 namespace Cycle\ORM\Tests\Fixtures;
 
-use Cycle\ORM\Select\ConstrainInterface;
 use Cycle\ORM\Select\QueryBuilder;
+use Cycle\ORM\Select\ScopeInterface;
 
-class SortByLevelConstrain implements ConstrainInterface
+class SortByIDScope implements ScopeInterface
 {
     public function apply(QueryBuilder $query): void
     {
-        $query->orderBy('level', 'ASC');
+        $query->orderBy('id', 'ASC');
     }
 }

--- a/tests/ORM/Fixtures/SortByLevelDESCScope.php
+++ b/tests/ORM/Fixtures/SortByLevelDESCScope.php
@@ -11,13 +11,13 @@ declare(strict_types=1);
 
 namespace Cycle\ORM\Tests\Fixtures;
 
-use Cycle\ORM\Select\ConstrainInterface;
 use Cycle\ORM\Select\QueryBuilder;
+use Cycle\ORM\Select\ScopeInterface;
 
-class SortByIDConstrain implements ConstrainInterface
+class SortByLevelDESCScope implements ScopeInterface
 {
     public function apply(QueryBuilder $query): void
     {
-        $query->orderBy('id', 'ASC');
+        $query->orderBy('level', 'DESC');
     }
 }

--- a/tests/ORM/Fixtures/SortByLevelScope.php
+++ b/tests/ORM/Fixtures/SortByLevelScope.php
@@ -11,13 +11,13 @@ declare(strict_types=1);
 
 namespace Cycle\ORM\Tests\Fixtures;
 
-use Cycle\ORM\Select\ConstrainInterface;
 use Cycle\ORM\Select\QueryBuilder;
+use Cycle\ORM\Select\ScopeInterface;
 
-class NotDeletedConstrain implements ConstrainInterface
+class SortByLevelScope implements ScopeInterface
 {
     public function apply(QueryBuilder $query): void
     {
-        $query->where('deleted_at', '=', null);
+        $query->orderBy('level', 'ASC');
     }
 }

--- a/tests/ORM/Fixtures/SortByMsgScope.php
+++ b/tests/ORM/Fixtures/SortByMsgScope.php
@@ -11,13 +11,13 @@ declare(strict_types=1);
 
 namespace Cycle\ORM\Tests\Fixtures;
 
-use Cycle\ORM\Select\ConstrainInterface;
 use Cycle\ORM\Select\QueryBuilder;
+use Cycle\ORM\Select\ScopeInterface;
 
-class SortByLevelDESCConstrain implements ConstrainInterface
+class SortByMsgScope implements ScopeInterface
 {
     public function apply(QueryBuilder $query): void
     {
-        $query->orderBy('level', 'DESC');
+        $query->orderBy('message', 'ASC');
     }
 }

--- a/tests/ORM/Fixtures/UserPromise.php
+++ b/tests/ORM/Fixtures/UserPromise.php
@@ -79,9 +79,7 @@ class UserPromise extends User implements PromiseInterface
 
             // Fetching from the database
             $select = new Select($this->orm, $this->target);
-            $this->resolved = $select->constrain(
-                $this->orm->getSource($this->target)->getConstrain()
-            )->fetchOne($this->scope);
+            $this->resolved = $select->scope($this->orm->getSource($this->target)->getScope())->fetchOne($this->scope);
 
             $this->orm = null;
         }

--- a/tests/ORM/HasManyConstrainTest.php
+++ b/tests/ORM/HasManyConstrainTest.php
@@ -18,7 +18,7 @@ use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
 use Cycle\ORM\Select\JoinableLoader;
 use Cycle\ORM\Tests\Fixtures\Comment;
-use Cycle\ORM\Tests\Fixtures\SortByIDConstrain;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
 use Cycle\ORM\Tests\Fixtures\User;
 use Cycle\ORM\Tests\Traits\TableTrait;
 use Spiral\Database\Exception\StatementException;
@@ -71,7 +71,7 @@ abstract class HasManyConstrainTest extends BaseTest
     public function testConstrainOrdered(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
         ]);
 
         [$a, $b] = (new Select($this->orm, User::class))->load('comments')->fetchAll();
@@ -92,7 +92,7 @@ abstract class HasManyConstrainTest extends BaseTest
     public function testConstrainOrderedAsc(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
         ]);
 
         [$a, $b] = (new Select($this->orm, User::class))->load('comments')->fetchAll();
@@ -113,7 +113,7 @@ abstract class HasManyConstrainTest extends BaseTest
     public function testConstrainOrderedAscInLoad(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
         ]);
 
         [$a, $b] = (new Select($this->orm, User::class))->load('comments', [
@@ -136,7 +136,7 @@ abstract class HasManyConstrainTest extends BaseTest
     public function testConstrainOrderedPromisedAsc(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
         ]);
 
         [$a, $b] = (new Select($this->orm, User::class))->fetchAll();
@@ -157,7 +157,7 @@ abstract class HasManyConstrainTest extends BaseTest
     public function testConstrainOrderedAndWhere(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
             Relation::SCHEMA  => [Relation::WHERE => ['@.level' => ['>=' => 2]]]
         ]);
 
@@ -176,7 +176,7 @@ abstract class HasManyConstrainTest extends BaseTest
     public function testConstrainOrderedAndWherePromised(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
             Relation::SCHEMA  => [Relation::WHERE => ['@.level' => ['>=' => 2]]]
         ]);
 
@@ -195,7 +195,7 @@ abstract class HasManyConstrainTest extends BaseTest
     public function testConstrainOrderedAndWhereReversed(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
             Relation::SCHEMA  => [Relation::WHERE => ['@.level' => ['>=' => 2]]]
         ]);
 
@@ -214,7 +214,7 @@ abstract class HasManyConstrainTest extends BaseTest
     public function testConstrainOrderedAndWhereReversedInload(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
             Relation::SCHEMA  => [Relation::WHERE => ['@.level' => ['>=' => 2]]]
         ]);
 
@@ -235,7 +235,7 @@ abstract class HasManyConstrainTest extends BaseTest
     public function testConstrainOrderedAndWhereReversedPromised(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
             Relation::SCHEMA  => [Relation::WHERE => ['@.level' => ['>=' => 2]]]
         ]);
 
@@ -254,7 +254,7 @@ abstract class HasManyConstrainTest extends BaseTest
     public function testConstrainOrderedAndCustomWhere(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
             Relation::SCHEMA  => [Relation::WHERE => ['@.level' => ['>=' => 2]]]
         ]);
 
@@ -273,7 +273,7 @@ abstract class HasManyConstrainTest extends BaseTest
     public function testConstrainOrderedAndCustomWhereInload(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
             Relation::SCHEMA  => [Relation::WHERE => ['@.level' => ['>=' => 2]]]
         ]);
 
@@ -293,7 +293,7 @@ abstract class HasManyConstrainTest extends BaseTest
     public function testOrderByWithConstrainOrdered(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
             Relation::SCHEMA  => [
                 Relation::ORDER_BY => ['@.level' => 'DESC'],
             ],
@@ -445,7 +445,7 @@ abstract class HasManyConstrainTest extends BaseTest
     {
         $this->orm = $this->withCommentsSchema([
             Relation::SCHEMA  => [Relation::WHERE => ['@.level' => ['>=' => 3]]],
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
         ]);
 
         // sort by users and then by comments and only include comments with level > 3
@@ -471,7 +471,7 @@ abstract class HasManyConstrainTest extends BaseTest
 
         $this->orm = $this->withCommentsSchema([
             Relation::SCHEMA  => [Relation::WHERE => ['@.level' => ['>=' => 3]]],
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.column' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.column' => 'DESC']),
         ]);
 
         // sort by users and then by comments and only include comments with level > 3
@@ -483,8 +483,8 @@ abstract class HasManyConstrainTest extends BaseTest
     protected function withCommentsSchema(array $relationSchema)
     {
         $eSchema = [];
-        if (isset($relationSchema[Schema::CONSTRAIN])) {
-            $eSchema[Schema::CONSTRAIN] = $relationSchema[Schema::CONSTRAIN];
+        if (isset($relationSchema[Schema::SCOPE])) {
+            $eSchema[Schema::SCOPE] = $relationSchema[Schema::SCOPE];
         }
 
         $rSchema = $relationSchema[Relation::SCHEMA] ?? [];
@@ -509,7 +509,7 @@ abstract class HasManyConstrainTest extends BaseTest
                             ] + $rSchema,
                     ]
                 ],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ],
             Comment::class => [
                     Schema::ROLE        => 'comment',

--- a/tests/ORM/HasManyNestedConditionTest.php
+++ b/tests/ORM/HasManyNestedConditionTest.php
@@ -17,7 +17,7 @@ use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
 use Cycle\ORM\Tests\Fixtures\Comment;
 use Cycle\ORM\Tests\Fixtures\Post;
-use Cycle\ORM\Tests\Fixtures\SortByIDConstrain;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
 use Cycle\ORM\Tests\Fixtures\User;
 use Cycle\ORM\Tests\Traits\TableTrait;
 use Spiral\Database\Injection\Expression;
@@ -121,7 +121,7 @@ abstract class HasManyNestedConditionTest extends BaseTest
                         ],
                     ]
                 ],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ],
             Comment::class => [
                 Schema::ROLE        => 'comment',

--- a/tests/ORM/HasManyPromiseTest.php
+++ b/tests/ORM/HasManyPromiseTest.php
@@ -20,7 +20,7 @@ use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
 use Cycle\ORM\Select\JoinableLoader;
 use Cycle\ORM\Tests\Fixtures\Comment;
-use Cycle\ORM\Tests\Fixtures\SortByIDConstrain;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
 use Cycle\ORM\Tests\Fixtures\User;
 use Cycle\ORM\Tests\Traits\TableTrait;
 use Cycle\ORM\Transaction;
@@ -95,7 +95,7 @@ abstract class HasManyPromiseTest extends BaseTest
                 Schema::COLUMNS     => ['id', 'user_id', 'message'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
 
             ]
         ]));

--- a/tests/ORM/HasManyRelationTest.php
+++ b/tests/ORM/HasManyRelationTest.php
@@ -19,7 +19,7 @@ use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
 use Cycle\ORM\Select\JoinableLoader;
 use Cycle\ORM\Tests\Fixtures\Comment;
-use Cycle\ORM\Tests\Fixtures\SortByIDConstrain;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
 use Cycle\ORM\Tests\Fixtures\User;
 use Cycle\ORM\Tests\Traits\TableTrait;
 use Cycle\ORM\Transaction;
@@ -95,7 +95,7 @@ abstract class HasManyRelationTest extends BaseTest
                 Schema::COLUMNS     => ['id', 'user_id', 'message'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ]
         ]));
     }
@@ -345,7 +345,7 @@ abstract class HasManyRelationTest extends BaseTest
                 Schema::COLUMNS     => ['id', 'user_id', 'message'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ]
         ]));
 

--- a/tests/ORM/HasManySourceTest.php
+++ b/tests/ORM/HasManySourceTest.php
@@ -16,8 +16,8 @@ use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
 use Cycle\ORM\Tests\Fixtures\Comment;
-use Cycle\ORM\Tests\Fixtures\LeveledHasManyConstrain;
-use Cycle\ORM\Tests\Fixtures\ShortLeveledHasManyConstrain;
+use Cycle\ORM\Tests\Fixtures\LeveledHasManyScope;
+use Cycle\ORM\Tests\Fixtures\ShortLeveledHasManyScope;
 use Cycle\ORM\Tests\Fixtures\User;
 use Cycle\ORM\Tests\Traits\TableTrait;
 
@@ -110,7 +110,7 @@ abstract class HasManySourceTest extends BaseTest
     public function testSelectUsersWithScope(): void
     {
         $s = new Select($this->orm, User::class);
-        $res = $s->constrain(new Select\QueryConstrain(['@.balance' => 100]))->fetchAll();
+        $res = $s->scope(new Select\Scope\QueryScope(['@.balance' => 100]))->fetchAll();
 
         $this->assertCount(1, $res);
         $this->assertSame('hello@world.com', $res[0]->email);
@@ -119,7 +119,7 @@ abstract class HasManySourceTest extends BaseTest
     public function testSelectUserScopeCanNotBeOverwritten(): void
     {
         $s = new Select($this->orm, User::class);
-        $s->constrain(new Select\QueryConstrain(['@.balance' => 100]));
+        $s->scope(new Select\Scope\QueryScope(['@.balance' => 100]));
 
         $res = $s->where('user.balance', 200)->fetchAll();
 
@@ -129,7 +129,7 @@ abstract class HasManySourceTest extends BaseTest
     public function testSelectUserScopeCanNotBeOverwritten2(): void
     {
         $s = new Select($this->orm, User::class);
-        $s->constrain(new Select\QueryConstrain(['@.balance' => 100]));
+        $s->scope(new Select\Scope\QueryScope(['@.balance' => 100]));
 
         $res = $s->orWhere('user.balance', 200)->fetchAll();
 
@@ -139,7 +139,7 @@ abstract class HasManySourceTest extends BaseTest
     public function testScopeWithOrderBy(): void
     {
         $s = new Select($this->orm, User::class);
-        $s->constrain(new Select\QueryConstrain([], ['@.balance' => 'DESC']));
+        $s->scope(new Select\Scope\QueryScope([], ['@.balance' => 'DESC']));
 
         $res = $s->fetchAll();
 
@@ -151,7 +151,7 @@ abstract class HasManySourceTest extends BaseTest
     public function testRelated(): void
     {
         $s = new Select($this->orm, User::class);
-        $s->constrain(new Select\QueryConstrain([], ['@.balance' => 'DESC']));
+        $s->scope(new Select\Scope\QueryScope([], ['@.balance' => 'DESC']));
 
         $res = $s->load('comments')->fetchAll();
 
@@ -175,10 +175,10 @@ abstract class HasManySourceTest extends BaseTest
     public function testRelatedScope(): void
     {
         $s = new Select($this->orm, User::class);
-        $s->constrain(new Select\QueryConstrain([], ['@.balance' => 'DESC']));
+        $s->scope(new Select\Scope\QueryScope([], ['@.balance' => 'DESC']));
 
         $res = $s->load('comments', [
-            'constrain' => new Select\QueryConstrain(['@.level' => 4])
+            'constrain' => new Select\Scope\QueryScope(['@.level' => 4])
         ])->fetchAll();
 
         [$b, $a] = $res;
@@ -192,11 +192,11 @@ abstract class HasManySourceTest extends BaseTest
     public function testRelatedScopeInload(): void
     {
         $s = new Select($this->orm, User::class);
-        $s->constrain(new Select\QueryConstrain([], ['@.balance' => 'DESC']));
+        $s->scope(new Select\Scope\QueryScope([], ['@.balance' => 'DESC']));
 
         $res = $s->load('comments', [
             'method'    => Select\JoinableLoader::INLOAD,
-            'constrain' => new Select\QueryConstrain(['@.level' => 4])
+            'constrain' => new Select\Scope\QueryScope(['@.level' => 4])
         ])->fetchAll();
 
         [$b, $a] = $res;
@@ -210,10 +210,10 @@ abstract class HasManySourceTest extends BaseTest
     public function testRelatedScopeOrdered(): void
     {
         $s = new Select($this->orm, User::class);
-        $s->constrain(new Select\QueryConstrain([], ['@.balance' => 'DESC']));
+        $s->scope(new Select\Scope\QueryScope([], ['@.balance' => 'DESC']));
 
         $res = $s->load('comments', [
-            'constrain' => new Select\QueryConstrain(['@.level' => ['>=' => 3]], ['@.level' => 'DESC'])
+            'constrain' => new Select\Scope\QueryScope(['@.level' => ['>=' => 3]], ['@.level' => 'DESC'])
         ])->fetchAll();
 
         [$b, $a] = $res;
@@ -230,11 +230,11 @@ abstract class HasManySourceTest extends BaseTest
     public function testRelatedScopeOrderedInload(): void
     {
         $s = new Select($this->orm, User::class);
-        $s->constrain(new Select\QueryConstrain([], ['@.balance' => 'DESC']));
+        $s->scope(new Select\Scope\QueryScope([], ['@.balance' => 'DESC']));
 
         $res = $s->load('comments', [
             'method'    => Select\JoinableLoader::INLOAD,
-            'constrain' => new Select\QueryConstrain(['@.level' => ['>=' => 3]], ['@.level' => 'DESC'])
+            'constrain' => new Select\Scope\QueryScope(['@.level' => ['>=' => 3]], ['@.level' => 'DESC'])
         ])->fetchAll();
 
         [$b, $a] = $res;
@@ -279,12 +279,12 @@ abstract class HasManySourceTest extends BaseTest
                 Schema::COLUMNS     => ['id', 'user_id', 'level', 'message'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => LeveledHasManyConstrain::class
+                Schema::SCOPE   => LeveledHasManyScope::class
             ]
         ]));
 
         $s = new Select($this->orm, User::class);
-        $s->constrain(new Select\QueryConstrain([], ['@.balance' => 'DESC']));
+        $s->scope(new Select\Scope\QueryScope([], ['@.balance' => 'DESC']));
 
         $res = $s->load('comments')->fetchAll();
 
@@ -330,12 +330,12 @@ abstract class HasManySourceTest extends BaseTest
                 Schema::COLUMNS     => ['id', 'user_id', 'level', 'message'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => LeveledHasManyConstrain::class
+                Schema::SCOPE   => LeveledHasManyScope::class
             ]
         ]));
 
         $s = new Select($this->orm, User::class);
-        $s->constrain(new Select\QueryConstrain([], ['@.balance' => 'DESC']));
+        $s->scope(new Select\Scope\QueryScope([], ['@.balance' => 'DESC']));
 
         $res = $s->load('comments', [
             'method' => Select\JoinableLoader::INLOAD,
@@ -384,12 +384,12 @@ abstract class HasManySourceTest extends BaseTest
                 Schema::COLUMNS     => ['id', 'user_id', 'level', 'message'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => LeveledHasManyConstrain::class
+                Schema::SCOPE   => LeveledHasManyScope::class
             ]
         ]));
 
         $s = new Select($this->orm, User::class);
-        $s->constrain(new Select\QueryConstrain([], ['@.balance' => 'DESC']));
+        $s->scope(new Select\Scope\QueryScope([], ['@.balance' => 'DESC']));
 
         $res = $s->fetchAll();
 
@@ -436,12 +436,12 @@ abstract class HasManySourceTest extends BaseTest
                 Schema::COLUMNS     => ['id', 'user_id', 'level', 'message'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => ShortLeveledHasManyConstrain::class
+                Schema::SCOPE   => ShortLeveledHasManyScope::class
             ]
         ]));
 
         $s = new Select($this->orm, User::class);
-        $s->constrain(new Select\QueryConstrain([], ['@.balance' => 'DESC']));
+        $s->scope(new Select\Scope\QueryScope([], ['@.balance' => 'DESC']));
 
         $res = $s->fetchAll();
 

--- a/tests/ORM/InstantiatorTest.php
+++ b/tests/ORM/InstantiatorTest.php
@@ -16,7 +16,7 @@ use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
 use Cycle\ORM\Tests\Fixtures\Comment;
-use Cycle\ORM\Tests\Fixtures\SortByIDConstrain;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
 use Cycle\ORM\Tests\Fixtures\WithConstructor;
 use Cycle\ORM\Tests\Traits\TableTrait;
 use Cycle\ORM\Transaction;
@@ -73,7 +73,7 @@ abstract class InstantiatorTest extends BaseTest
                 Schema::COLUMNS     => ['id', 'user_id', 'message'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ]
         ]));
     }

--- a/tests/ORM/InverseRelationTest.php
+++ b/tests/ORM/InverseRelationTest.php
@@ -17,7 +17,7 @@ use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
 use Cycle\ORM\Tests\Fixtures\Profile;
-use Cycle\ORM\Tests\Fixtures\SortByIDConstrain;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
 use Cycle\ORM\Tests\Fixtures\User;
 use Cycle\ORM\Tests\Traits\TableTrait;
 use Cycle\ORM\Transaction;
@@ -81,7 +81,7 @@ abstract class InverseRelationTest extends BaseTest
                         ],
                     ]
                 ],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ],
             Profile::class => [
                 Schema::ROLE        => 'profile',
@@ -102,7 +102,7 @@ abstract class InverseRelationTest extends BaseTest
                         ],
                     ],
                 ],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ],
         ]));
     }

--- a/tests/ORM/ManyToManyConstrainTest.php
+++ b/tests/ORM/ManyToManyConstrainTest.php
@@ -91,7 +91,7 @@ abstract class ManyToManyConstrainTest extends BaseTest
     public function testConstrainOrdered(): void
     {
         $this->orm = $this->withTagSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
         ]);
 
         $selector = new Select($this->orm, User::class);
@@ -118,7 +118,7 @@ abstract class ManyToManyConstrainTest extends BaseTest
     public function testConstrainOrderedDesc(): void
     {
         $this->orm = $this->withTagSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
         ]);
 
         $selector = new Select($this->orm, User::class);
@@ -145,7 +145,7 @@ abstract class ManyToManyConstrainTest extends BaseTest
     public function testConstrainOrderedInload(): void
     {
         $this->orm = $this->withTagSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
         ]);
 
         $selector = new Select($this->orm, User::class);
@@ -174,7 +174,7 @@ abstract class ManyToManyConstrainTest extends BaseTest
     public function testWithOrderByAndConstrainOrdered(): void
     {
         $this->orm = $this->withTagSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
             Relation::SCHEMA  => [Relation::ORDER_BY => ['@.level' => 'ASC']],
         ]);
 
@@ -341,7 +341,7 @@ abstract class ManyToManyConstrainTest extends BaseTest
     public function testConstrainOrderedDESCInload(): void
     {
         $this->orm = $this->withTagSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
         ]);
 
         $selector = new Select($this->orm, User::class);
@@ -370,7 +370,7 @@ abstract class ManyToManyConstrainTest extends BaseTest
     public function testConstrainOrderedPromisedASC(): void
     {
         $this->orm = $this->withTagSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
         ]);
 
         $selector = new Select($this->orm, User::class);
@@ -399,7 +399,7 @@ abstract class ManyToManyConstrainTest extends BaseTest
     public function testConstrainOrderedPromisedDESC(): void
     {
         $this->orm = $this->withTagSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
         ]);
 
         $selector = new Select($this->orm, User::class);
@@ -428,7 +428,7 @@ abstract class ManyToManyConstrainTest extends BaseTest
     public function testConstrainOrderedAndWhere(): void
     {
         $this->orm = $this->withTagSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
             Relation::SCHEMA  => [Relation::WHERE => ['@.level' => ['>=' => 3]]],
         ]);
 
@@ -482,7 +482,7 @@ abstract class ManyToManyConstrainTest extends BaseTest
     public function testConstrainOrderedDESCAndWhere(): void
     {
         $this->orm = $this->withTagSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
             Relation::SCHEMA  => [Relation::WHERE => ['@.level' => ['>=' => 3]]],
         ]);
 
@@ -508,7 +508,7 @@ abstract class ManyToManyConstrainTest extends BaseTest
     public function testConstrainOrderedAndWhereInload(): void
     {
         $this->orm = $this->withTagSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
             Relation::SCHEMA  => [Relation::WHERE => ['@.level' => ['>=' => 3]]],
         ]);
 
@@ -536,7 +536,7 @@ abstract class ManyToManyConstrainTest extends BaseTest
     public function testConstrainOrderedDESCAndWhereInload(): void
     {
         $this->orm = $this->withTagSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
             Relation::SCHEMA  => [Relation::WHERE => ['@.level' => ['>=' => 3]]],
         ]);
 
@@ -564,7 +564,7 @@ abstract class ManyToManyConstrainTest extends BaseTest
     public function testConstrainOrderedAndWherePromise(): void
     {
         $this->orm = $this->withTagSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
             Relation::SCHEMA  => [Relation::WHERE => ['@.level' => ['>=' => 3]]],
         ]);
 
@@ -592,7 +592,7 @@ abstract class ManyToManyConstrainTest extends BaseTest
     public function testOrderedDESCAndWherePromise(): void
     {
         $this->orm = $this->withTagSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
             Relation::SCHEMA  => [Relation::WHERE => ['@.level' => ['>=' => 3]]],
         ]);
 
@@ -620,7 +620,7 @@ abstract class ManyToManyConstrainTest extends BaseTest
     public function testCustomWhere(): void
     {
         $this->orm = $this->withTagSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
             Relation::SCHEMA  => [Relation::WHERE => ['@.level' => ['>=' => 3]]],
         ]);
 
@@ -643,7 +643,7 @@ abstract class ManyToManyConstrainTest extends BaseTest
     public function testCustomWhereInload(): void
     {
         $this->orm = $this->withTagSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
             Relation::SCHEMA  => [Relation::WHERE => ['@.level' => ['>=' => 3]]],
         ]);
 
@@ -731,7 +731,7 @@ abstract class ManyToManyConstrainTest extends BaseTest
         $this->expectException(StatementException::class);
 
         $this->orm = $this->withTagSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.column' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.column' => 'ASC']),
         ]);
 
         $selector = new Select($this->orm, User::class);
@@ -742,8 +742,8 @@ abstract class ManyToManyConstrainTest extends BaseTest
     protected function withTagSchema(array $relationSchema)
     {
         $eSchema = [];
-        if (isset($relationSchema[Schema::CONSTRAIN])) {
-            $eSchema[Schema::CONSTRAIN] = $relationSchema[Schema::CONSTRAIN];
+        if (isset($relationSchema[Schema::SCOPE])) {
+            $eSchema[Schema::SCOPE] = $relationSchema[Schema::SCOPE];
         }
 
         $rSchema = $relationSchema[Relation::SCHEMA] ?? [];

--- a/tests/ORM/ManyToManyConstrainedPivotTest.php
+++ b/tests/ORM/ManyToManyConstrainedPivotTest.php
@@ -15,7 +15,7 @@ use Cycle\ORM\Mapper\Mapper;
 use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
-use Cycle\ORM\Tests\Fixtures\SortByLevelDESCConstrain;
+use Cycle\ORM\Tests\Fixtures\SortByLevelDESCScope;
 use Cycle\ORM\Tests\Fixtures\Tag;
 use Cycle\ORM\Tests\Fixtures\TagContext;
 use Cycle\ORM\Tests\Fixtures\User;
@@ -207,7 +207,7 @@ abstract class ManyToManyConstrainedPivotTest extends BaseTest
     public function testLoadRelationOrderByPivotColumn(): void
     {
         $this->orm = $this->withPivotSchema([
-            Schema::CONSTRAIN => SortByLevelDESCConstrain::class,
+            Schema::SCOPE => SortByLevelDESCScope::class,
         ]);
 
         $selector = new Select($this->orm, User::class);
@@ -319,7 +319,7 @@ abstract class ManyToManyConstrainedPivotTest extends BaseTest
     public function testLoaderRelationWithConstrain(): void
     {
         $this->orm = $this->withPivotSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain(
+            Schema::SCOPE => new Select\Scope\QueryScope(
                 ['@.level' => ['>' => 3]],
                 ['@.level' => 'DESC']
             ),

--- a/tests/ORM/ManyToManyConstrainedTest.php
+++ b/tests/ORM/ManyToManyConstrainedTest.php
@@ -15,8 +15,8 @@ use Cycle\ORM\Mapper\Mapper;
 use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
-use Cycle\ORM\Tests\Fixtures\SortByLevelConstrain;
-use Cycle\ORM\Tests\Fixtures\SortByLevelDESCConstrain;
+use Cycle\ORM\Tests\Fixtures\SortByLevelDESCScope;
+use Cycle\ORM\Tests\Fixtures\SortByLevelScope;
 use Cycle\ORM\Tests\Fixtures\Tag;
 use Cycle\ORM\Tests\Fixtures\TagContext;
 use Cycle\ORM\Tests\Fixtures\User;
@@ -91,7 +91,7 @@ abstract class ManyToManyConstrainedTest extends BaseTest
     public function testOrderedByScope(): void
     {
         $this->orm = $this->withTagSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC'])
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC'])
         ]);
 
         $selector = new Select($this->orm, User::class);
@@ -126,7 +126,7 @@ abstract class ManyToManyConstrainedTest extends BaseTest
          * @var User $b
          */
         [$a, $b] = $selector->load('tags', [
-            'constrain' => new Select\QueryConstrain([], ['@.level' => 'DESC'])
+            'constrain' => new Select\Scope\QueryScope([], ['@.level' => 'DESC'])
         ])->fetchAll();
 
         $this->assertCount(4, $a->tags);
@@ -154,7 +154,7 @@ abstract class ManyToManyConstrainedTest extends BaseTest
          */
         [$a, $b] = $selector->load('tags', [
             'method'    => Select\JoinableLoader::INLOAD,
-            'constrain' => new Select\QueryConstrain([], ['@.level' => 'ASC'])
+            'constrain' => new Select\Scope\QueryScope([], ['@.level' => 'ASC'])
         ])->orderBy('user.id')->fetchAll();
 
         $this->assertCount(4, $a->tags);
@@ -182,7 +182,7 @@ abstract class ManyToManyConstrainedTest extends BaseTest
          */
         [$a, $b] = $selector->load('tags', [
             'method'    => Select\JoinableLoader::INLOAD,
-            'constrain' => new Select\QueryConstrain([], ['@.level' => 'DESC'])
+            'constrain' => new Select\Scope\QueryScope([], ['@.level' => 'DESC'])
         ])->orderBy('user.id')->fetchAll();
 
         $this->assertCount(4, $a->tags);
@@ -233,7 +233,7 @@ abstract class ManyToManyConstrainedTest extends BaseTest
                 Schema::COLUMNS     => ['id', 'name', 'level'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => SortByLevelConstrain::class
+                Schema::SCOPE   => SortByLevelScope::class
             ],
             TagContext::class => [
                 Schema::ROLE        => 'tag_context',
@@ -306,7 +306,7 @@ abstract class ManyToManyConstrainedTest extends BaseTest
                 Schema::COLUMNS     => ['id', 'name', 'level'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => SortByLevelDESCConstrain::class
+                Schema::SCOPE   => SortByLevelDESCScope::class
             ],
             TagContext::class => [
                 Schema::ROLE        => 'tag_context',
@@ -379,7 +379,7 @@ abstract class ManyToManyConstrainedTest extends BaseTest
                 Schema::COLUMNS     => ['id', 'name', 'level'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => SortByLevelDESCConstrain::class
+                Schema::SCOPE   => SortByLevelDESCScope::class
             ],
             TagContext::class => [
                 Schema::ROLE        => 'tag_context',
@@ -401,7 +401,7 @@ abstract class ManyToManyConstrainedTest extends BaseTest
          * @var User $b
          */
         [$a, $b] = $selector->load('tags', [
-            'constrain' => new SortByLevelConstrain()
+            'constrain' => new SortByLevelScope()
         ])->orderBy('user.id')->fetchAll();
 
         $this->captureReadQueries();
@@ -455,7 +455,7 @@ abstract class ManyToManyConstrainedTest extends BaseTest
                 Schema::COLUMNS     => ['id', 'name', 'level'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => SortByLevelConstrain::class
+                Schema::SCOPE   => SortByLevelScope::class
             ],
             TagContext::class => [
                 Schema::ROLE        => 'tag_context',
@@ -529,7 +529,7 @@ abstract class ManyToManyConstrainedTest extends BaseTest
                 Schema::COLUMNS     => ['id', 'name', 'level'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => SortByLevelDESCConstrain::class
+                Schema::SCOPE   => SortByLevelDESCScope::class
             ],
             TagContext::class => [
                 Schema::ROLE        => 'tag_context',

--- a/tests/ORM/ManyToManyDeepenedTest.php
+++ b/tests/ORM/ManyToManyDeepenedTest.php
@@ -17,7 +17,7 @@ use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
 use Cycle\ORM\Tests\Fixtures\Image;
-use Cycle\ORM\Tests\Fixtures\SortByIDConstrain;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
 use Cycle\ORM\Tests\Fixtures\Tag;
 use Cycle\ORM\Tests\Fixtures\TagContext;
 use Cycle\ORM\Tests\Fixtures\User;
@@ -133,7 +133,7 @@ abstract class ManyToManyDeepenedTest extends BaseTest
                 Schema::TYPECAST    => ['id' => 'int'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ],
             TagContext::class => [
                 Schema::ROLE        => 'tag_context',

--- a/tests/ORM/ManyToManyPromiseEagerLoadTest.php
+++ b/tests/ORM/ManyToManyPromiseEagerLoadTest.php
@@ -15,7 +15,7 @@ use Cycle\ORM\Mapper\StdMapper;
 use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
-use Cycle\ORM\Tests\Fixtures\SortByIDConstrain;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
 use Cycle\ORM\Tests\Traits\TableTrait;
 
 abstract class ManyToManyPromiseEagerLoadTest extends BaseTest
@@ -118,7 +118,7 @@ abstract class ManyToManyPromiseEagerLoadTest extends BaseTest
                         ],
                     ]
                 ],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ],
             'version_distribution' => [
                 Schema::ROLE        => 'version_context',
@@ -152,7 +152,7 @@ abstract class ManyToManyPromiseEagerLoadTest extends BaseTest
                         ],
                     ]
                 ],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ],
             'module'               => [
                 Schema::ROLE        => 'module',
@@ -164,7 +164,7 @@ abstract class ManyToManyPromiseEagerLoadTest extends BaseTest
                 Schema::TYPECAST    => ['id' => 'int'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ]
         ]));
     }

--- a/tests/ORM/ManyToManyPromiseTest.php
+++ b/tests/ORM/ManyToManyPromiseTest.php
@@ -17,7 +17,7 @@ use Cycle\ORM\Promise\Collection\CollectionPromiseInterface;
 use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
-use Cycle\ORM\Tests\Fixtures\SortByIDConstrain;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
 use Cycle\ORM\Tests\Fixtures\Tag;
 use Cycle\ORM\Tests\Fixtures\TagContext;
 use Cycle\ORM\Tests\Fixtures\User;
@@ -117,7 +117,7 @@ abstract class ManyToManyPromiseTest extends BaseTest
                 Schema::TYPECAST    => ['id' => 'int'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ],
             TagContext::class => [
                 Schema::ROLE        => 'tag_context',

--- a/tests/ORM/ManyToManyRelationTest.php
+++ b/tests/ORM/ManyToManyRelationTest.php
@@ -13,7 +13,6 @@ namespace Cycle\ORM\Tests;
 
 use Cycle\ORM\Heap\Heap;
 use Cycle\ORM\Mapper\Mapper;
-use Cycle\ORM\Promise\Collection\CollectionPromiseInterface;
 use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
@@ -202,7 +201,7 @@ abstract class ManyToManyRelationTest extends BaseTest
         $selector = new Select($this->orm, User::class);
         $selector->load('tags', [
             'method'    => Select\JoinableLoader::INLOAD,
-            'constrain' => new Select\QueryConstrain([], ['id' => 'ASC'])
+            'constrain' => new Select\Scope\QueryScope([], ['id' => 'ASC'])
         ])->orderBy(['id' => 'ASC']);
 
         $this->assertSame([

--- a/tests/ORM/Morphed/MorphedHasManyConstrainTest.php
+++ b/tests/ORM/Morphed/MorphedHasManyConstrainTest.php
@@ -19,7 +19,7 @@ use Cycle\ORM\Select;
 use Cycle\ORM\Tests\BaseTest;
 use Cycle\ORM\Tests\Fixtures\Comment;
 use Cycle\ORM\Tests\Fixtures\Post;
-use Cycle\ORM\Tests\Fixtures\SortByIDConstrain;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
 use Cycle\ORM\Tests\Fixtures\User;
 use Cycle\ORM\Tests\Traits\TableTrait;
 use Spiral\Database\Exception\StatementException;
@@ -95,7 +95,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     public function testOrdered(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
         ]);
 
         [$a, $b] = (new Select($this->orm, User::class))->load('comments')->fetchAll();
@@ -116,7 +116,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     public function testOrderedASC(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
         ]);
 
         [$a, $b] = (new Select($this->orm, User::class))->load('comments')->fetchAll();
@@ -137,7 +137,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     public function testOrderedPosts(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
         ]);
 
         [$a, $b] = (new Select($this->orm, Post::class))->load('comments')->fetchAll();
@@ -158,7 +158,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     public function testOrderedPostsASC(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
         ]);
 
         [$a, $b] = (new Select($this->orm, Post::class))->load('comments')->fetchAll();
@@ -179,7 +179,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     public function testOrderedInload(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
         ]);
 
         [$a, $b] = (new Select($this->orm, User::class))->load('comments', [
@@ -202,7 +202,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     public function testOrderedASCInload(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
         ]);
 
         [$a, $b] = (new Select($this->orm, User::class))->load('comments', [
@@ -225,7 +225,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     public function testOrderedPostsInload(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
         ]);
 
         [$a, $b] = (new Select($this->orm, Post::class))->load('comments', [
@@ -248,7 +248,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     public function testOrderedPostsASCInload(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
         ]);
 
         [$a, $b] = (new Select($this->orm, Post::class))->load('comments', [
@@ -271,7 +271,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     public function testOrderedPromisedASC(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
         ]);
 
         [$a, $b] = (new Select($this->orm, User::class))->fetchAll();
@@ -292,7 +292,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     public function testOrderedAndWhere(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
             Relation::WHERE   => ['@.level' => ['>=' => 2]]
         ]);
 
@@ -311,7 +311,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     public function testOrderedAndWherePromised(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
             Relation::WHERE   => ['@.level' => ['>=' => 2]]
         ]);
 
@@ -330,7 +330,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     public function testPostOrderedPromisedASC(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
         ]);
 
         [$a, $b] = (new Select($this->orm, Post::class))->fetchAll();
@@ -351,7 +351,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     public function testPostOrderedAndWhere(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
             Relation::WHERE   => ['@.level' => ['>=' => 2]]
         ]);
 
@@ -370,7 +370,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     public function testPostOrderedAndWherePromised(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
             Relation::WHERE   => ['@.level' => ['>=' => 2]]
         ]);
 
@@ -391,7 +391,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     public function testOrderedAndWhereReversed(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
             Relation::WHERE   => ['@.level' => ['>=' => 2]]
         ]);
 
@@ -410,7 +410,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     public function testOrderedAndWhereReversedInload(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
             Relation::WHERE   => ['@.level' => ['>=' => 2]]
         ]);
 
@@ -432,7 +432,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     public function testOrderedAndWhereReversedPromised(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
             Relation::WHERE   => ['@.level' => ['>=' => 2]]
         ]);
 
@@ -451,7 +451,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     public function testCustomWhere(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
             Relation::WHERE   => ['@.level' => ['>=' => 2]]
         ]);
 
@@ -470,7 +470,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     public function testCustomWhereInload(): void
     {
         $this->orm = $this->withCommentsSchema([
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'ASC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'ASC']),
             Relation::WHERE   => ['@.level' => ['>=' => 2]]
         ]);
 
@@ -547,7 +547,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
     {
         $this->orm = $this->withCommentsSchema([
             Relation::WHERE   => ['@.level' => ['>=' => 3]],
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.level' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.level' => 'DESC']),
         ]);
 
         // sort by users and then by comments and only include comments with level > 3
@@ -573,7 +573,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
 
         $this->orm = $this->withCommentsSchema([
             Relation::WHERE   => ['@.level' => ['>=' => 3]],
-            Schema::CONSTRAIN => new Select\QueryConstrain([], ['@.column' => 'DESC']),
+            Schema::SCOPE => new Select\Scope\QueryScope([], ['@.column' => 'DESC']),
         ]);
 
         // sort by users and then by comments and only include comments with level > 3
@@ -587,8 +587,8 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
         $eSchema = [];
         $rSchema = [];
 
-        if (isset($relationSchema[Schema::CONSTRAIN])) {
-            $eSchema[Schema::CONSTRAIN] = $relationSchema[Schema::CONSTRAIN];
+        if (isset($relationSchema[Schema::SCOPE])) {
+            $eSchema[Schema::SCOPE] = $relationSchema[Schema::SCOPE];
         }
 
         if (isset($relationSchema[Relation::WHERE])) {
@@ -617,7 +617,7 @@ abstract class MorphedHasManyConstrainTest extends BaseTest
                             ] + $rSchema,
                     ]
                 ],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ],
             Post::class    => [
                 Schema::ROLE        => 'post',

--- a/tests/ORM/QueryBuilderTest.php
+++ b/tests/ORM/QueryBuilderTest.php
@@ -16,7 +16,7 @@ use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
 use Cycle\ORM\Tests\Fixtures\Comment;
-use Cycle\ORM\Tests\Fixtures\SortByIDConstrain;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
 use Cycle\ORM\Tests\Fixtures\User;
 use Cycle\ORM\Tests\Traits\TableTrait;
 use Spiral\Database\Injection\Parameter;
@@ -99,7 +99,7 @@ abstract class QueryBuilderTest extends BaseTest
                 ],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ]
         ]));
     }

--- a/tests/ORM/RelationWithColumnAliasTest.php
+++ b/tests/ORM/RelationWithColumnAliasTest.php
@@ -20,7 +20,7 @@ use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
 use Cycle\ORM\Select\JoinableLoader;
 use Cycle\ORM\Tests\Fixtures\Comment;
-use Cycle\ORM\Tests\Fixtures\SortByIDConstrain;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
 use Cycle\ORM\Tests\Fixtures\User;
 use Cycle\ORM\Tests\Traits\TableTrait;
 use Cycle\ORM\Transaction;
@@ -96,7 +96,7 @@ abstract class RelationWithColumnAliasTest extends BaseTest
                 Schema::COLUMNS     => ['id' => 'id_int', 'user_id' => 'user_id_int', 'message' => 'message_str'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ]
         ]));
     }

--- a/tests/ORM/SoftDeletesTest.php
+++ b/tests/ORM/SoftDeletesTest.php
@@ -14,7 +14,7 @@ namespace Cycle\ORM\Tests;
 use Cycle\ORM\Heap\Heap;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
-use Cycle\ORM\Tests\Fixtures\NotDeletedConstrain;
+use Cycle\ORM\Tests\Fixtures\NotDeletedScope;
 use Cycle\ORM\Tests\Fixtures\SoftDeletedMapper;
 use Cycle\ORM\Tests\Fixtures\User;
 use Cycle\ORM\Tests\Traits\TableTrait;
@@ -50,7 +50,7 @@ abstract class SoftDeletesTest extends BaseTest
                 ],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => NotDeletedConstrain::class
+                Schema::SCOPE   => NotDeletedScope::class
             ]
         ]));
     }
@@ -92,12 +92,12 @@ abstract class SoftDeletesTest extends BaseTest
 
         $orm = $this->orm->withHeap(new Heap());
         $s = new Select($orm, User::class);
-        $s->constrain(new NotDeletedConstrain());
+        $s->scope(new NotDeletedScope());
         $this->assertNull($s->fetchOne());
 
         $orm = $this->orm->withHeap(new Heap());
         $s = new Select($orm, User::class);
-        $s->constrain(null);
+        $s->scope(null);
         $this->assertNotNull($s->fetchOne());
     }
 }

--- a/tests/ORM/TypecastTest.php
+++ b/tests/ORM/TypecastTest.php
@@ -16,7 +16,7 @@ use Cycle\ORM\Heap\Node;
 use Cycle\ORM\Mapper\Mapper;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
-use Cycle\ORM\Tests\Fixtures\SortByIDConstrain;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
 use Cycle\ORM\Tests\Fixtures\User;
 use Cycle\ORM\Tests\Traits\TableTrait;
 use Cycle\ORM\Transaction;
@@ -59,7 +59,7 @@ abstract class TypecastTest extends BaseTest
                 ],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => SortByIDConstrain::class
+                Schema::SCOPE   => SortByIDScope::class
             ]
         ]));
     }

--- a/tests/ORM/UUIDTest.php
+++ b/tests/ORM/UUIDTest.php
@@ -17,7 +17,7 @@ use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
 use Cycle\ORM\Tests\Fixtures\Comment;
-use Cycle\ORM\Tests\Fixtures\SortByMsgConstrain;
+use Cycle\ORM\Tests\Fixtures\SortByMsgScope;
 use Cycle\ORM\Tests\Fixtures\User;
 use Cycle\ORM\Tests\Fixtures\UUIDMapper;
 use Cycle\ORM\Tests\Traits\TableTrait;
@@ -107,7 +107,7 @@ abstract class UUIDTest extends BaseTest
                 Schema::COLUMNS     => ['id', 'user_id', 'message'],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [],
-                Schema::CONSTRAIN   => SortByMsgConstrain::class
+                Schema::SCOPE   => SortByMsgScope::class
             ]
         ]));
     }


### PR DESCRIPTION
Closes #65

- Replace "constrain" with "scope" all over the code base
- Add BC aliases with deprecation replacement suggestion (need to ignore cs warning on alias files)