### PR TITLE
Fix type assertions for mapped columns

### DIFF
--- a/src/Parser/AbstractNode.php
+++ b/src/Parser/AbstractNode.php
@@ -138,7 +138,7 @@ abstract class AbstractNode
         if ($this->deduplicate($data)) {
             foreach ($this->trackReferences as $key) {
                 if (!empty($data[$key])) {
-                    $this->references[$key][$data[$key]][] = &$data;
+                    $this->references[$key][(string)$data[$key]][] = &$data;
                 }
             }
 
@@ -294,6 +294,8 @@ abstract class AbstractNode
             end($this->references[$key]);
             $criteria = key($this->references[$key]);
         }
+
+        $criteria = (string)$criteria;
 
         if (!array_key_exists($criteria, $this->references[$key])) {
             throw new ParserException("Undefined reference `{$key}`.`{$criteria}`");


### PR DESCRIPTION
Fix errors:

- Fatal error: Uncaught TypeError: Illegal offset type in /app/vendor/cycle/orm/src/Parser/AbstractNode.php on line 141
- Fatal error: Uncaught TypeError: array_key_exists(): Argument #1 ($key) must be a valid array offset type in /app/vendor/cycle/orm/src/Parser/AbstractNode.php on line 300


On code:

```
/** @var Contract $c */
$c = $repository->select()->load('config')->wherePK('d4922d32-d6b8-4ba3-9d2b-13d8b3dfa8db')->fetchOne();
```

```
return new ORM\Schema(
            [
                'contract' => [
                    // ...
                    ORM\Schema::PRIMARY_KEY => 'uuid',
                    ORM\Schema::COLUMNS => [
                        'uuid' => 'uuid',
                        'configUuid' => 'config_uuid',
                    ],
                    ORM\Schema::TYPECAST => [
                        'uuid' => [Store\Typecast\Uuid::class, 'cast'],
                        'configUuid' => [Store\Typecast\Uuid::class, 'cast'],
                    ],
                    ORM\Schema::RELATIONS => [
                        'config' => [
                            ORM\Relation::TYPE => ORM\Relation::BELONGS_TO,
                            ORM\Relation::TARGET => Config::class,
                            ORM\Relation::SCHEMA => [
                                ORM\Relation::CASCADE => true,
                                ORM\Relation::INNER_KEY => 'configUuid',
                                ORM\Relation::OUTER_KEY => 'uuid',
                            ],
                        ],
                    ],
                ],
                'config' => [
                    // ...
                    ORM\Schema::PRIMARY_KEY => 'uuid',
                    ORM\Schema::COLUMNS => [
                        'uuid' => 'uuid',
                    ],
                    ORM\Schema::TYPECAST => [
                        'uuid' => [Store\Typecast\Uuid::class, 'cast'],
                    ],
                ],
            ]
        );
```
