### PR TITLE
refactor: prevent repeating entity hydration in MtM relation

### DIFF
--- a/src/Iterator.php
+++ b/src/Iterator.php
@@ -18,24 +18,16 @@ use Cycle\ORM\Heap\Node;
  */
 final class Iterator implements \IteratorAggregate
 {
-    /**
-     * @var ORMInterface
-     */
+    /** @var ORMInterface */
     private $orm;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $role;
 
-    /**
-     * @var iterable
-     */
+    /** @var iterable */
     private $source;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $tryToFindInHeap;
 
     /**

--- a/src/Relation/ManyToMany.php
+++ b/src/Relation/ManyToMany.php
@@ -56,7 +56,7 @@ class ManyToMany extends Relation\AbstractRelation
         $elements = [];
         $pivotData = new \SplObjectStorage();
 
-        $iterator = new Iterator($this->orm, $this->target, $data);
+        $iterator = new Iterator($this->orm, $this->target, $data, true);
         foreach ($iterator as $pivot => $entity) {
             if (!is_array($pivot)) {
                 // skip partially selected entities (DB level filter)

--- a/src/Relation/Pivoted/PivotedPromise.php
+++ b/src/Relation/Pivoted/PivotedPromise.php
@@ -143,7 +143,8 @@ final class PivotedPromise implements PromiseInterface
 
         $elements = [];
         $pivotData = new \SplObjectStorage();
-        foreach (new Iterator($this->orm, $this->target, $root->getResult()[0]['output']) as $pivot => $entity) {
+        $iterator = new Iterator($this->orm, $this->target, $root->getResult()[0]['output'], true);
+        foreach ($iterator as $pivot => $entity) {
             $pivotData[$entity] = $this->orm->make(
                 $this->relationSchema[Relation::THROUGH_ENTITY],
                 $pivot,

--- a/tests/ORM/Fixtures/RbacItemAbstract.php
+++ b/tests/ORM/Fixtures/RbacItemAbstract.php
@@ -14,9 +14,7 @@ class RbacItemAbstract
      */
     public $name;
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     public $description;
 
     /**
@@ -31,7 +29,7 @@ class RbacItemAbstract
      */
     public $children;
 
-    public function __construct(string $name, ?string $description = null)
+    public function __construct(string $name, string $description = null)
     {
         $this->name = $name;
         $this->description = $description;

--- a/tests/ORM/Fixtures/RbacItemAbstract.php
+++ b/tests/ORM/Fixtures/RbacItemAbstract.php
@@ -15,6 +15,11 @@ class RbacItemAbstract
     public $name;
 
     /**
+     * @var string|null
+     */
+    public $description;
+
+    /**
      * @var DoctrineCollection|RbacRole[]|RbacPermission[]
      * @phpstan-var DoctrineCollection<string,RbacRole|RbacPermission>
      */
@@ -26,9 +31,10 @@ class RbacItemAbstract
      */
     public $children;
 
-    public function __construct(string $name)
+    public function __construct(string $name, ?string $description = null)
     {
         $this->name = $name;
+        $this->description = $description;
 
         $this->parents = new ArrayCollection();
         $this->children = new ArrayCollection();

--- a/tests/ORM/ManyToManySingleEntityTest.php
+++ b/tests/ORM/ManyToManySingleEntityTest.php
@@ -186,6 +186,6 @@ abstract class ManyToManySingleEntityTest extends BaseTest
 
         self::assertSame('updated description', $fetchedRole->description);
 
-        $this->save($fetchedRole);
+        $this->orm = $this->orm->withHeap(new Heap());
     }
 }

--- a/tests/ORM/ManyToManySingleEntityTest.php
+++ b/tests/ORM/ManyToManySingleEntityTest.php
@@ -167,9 +167,7 @@ abstract class ManyToManySingleEntityTest extends BaseTest
         $role->children->add($permission);
         $permission->parents->add($role);
 
-        $tr = new Transaction($this->orm);
-        $tr->persist($role);
-        $tr->run();
+        $this->save($role);
 
         unset($role, $permission);
 
@@ -188,8 +186,6 @@ abstract class ManyToManySingleEntityTest extends BaseTest
 
         self::assertSame('updated description', $fetchedRole->description);
 
-        $tr = new Transaction($this->orm);
-        $tr->persist($fetchedRole);
-        $tr->run();
+        $this->save($fetchedRole);
     }
 }

--- a/tests/ORM/ManyToManySingleEntityTest.php
+++ b/tests/ORM/ManyToManySingleEntityTest.php
@@ -8,7 +8,6 @@ use Cycle\ORM\Heap\Heap;
 use Cycle\ORM\Mapper\Mapper;
 use Cycle\ORM\Mapper\StdMapper;
 use Cycle\ORM\Relation;
-use Cycle\ORM\Relation\Pivoted\PivotedCollection;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
 use Cycle\ORM\Tests\Fixtures\RbacItemAbstract;
@@ -27,6 +26,7 @@ abstract class ManyToManySingleEntityTest extends BaseTest
 
         $this->makeTable('rbac_item', [
             'name' => 'string,primary',
+            'description' => 'string,nullable',
             '_type' => 'string,nullable',
         ]);
 
@@ -50,7 +50,7 @@ abstract class ManyToManySingleEntityTest extends BaseTest
                 Schema::DATABASE => 'default',
                 Schema::TABLE => 'rbac_item',
                 Schema::PRIMARY_KEY => 'name',
-                Schema::COLUMNS => ['name', '_type'],
+                Schema::COLUMNS => ['name', 'description', '_type'],
                 Schema::RELATIONS => [
                     'parents' => [
                         Relation::TYPE => Relation::MANY_TO_MANY,
@@ -156,5 +156,40 @@ abstract class ManyToManySingleEntityTest extends BaseTest
         $tr->run();
 
         self::assertTrue(true);
+    }
+
+    public function testNotTriggersRehydrate(): void
+    {
+        $role = new RbacRole('superAdmin', 'description');
+
+        $permission = new RbacPermission('writeUser');
+
+        $role->children->add($permission);
+        $permission->parents->add($role);
+
+        $tr = new Transaction($this->orm);
+        $tr->persist($role);
+        $tr->run();
+
+        unset($role, $permission);
+
+        $this->orm = $this->orm->withHeap(new Heap());
+
+        /** @var RbacRole $fetchedRole */
+        $fetchedRole = (new Select($this->orm, 'rbac_item'))->wherePK('superAdmin')->fetchOne();
+        /** @var RbacPermission $fetchedPermission */
+        $fetchedPermission = (new Select($this->orm, 'rbac_item'))->wherePK('writeUser')->fetchOne();
+
+        $fetchedRole->description = 'updated description';
+
+        // unlink
+        $fetchedRole->children->removeElement($fetchedPermission);
+        $fetchedPermission->parents->removeElement($fetchedRole);
+
+        self::assertSame('updated description', $fetchedRole->description);
+
+        $tr = new Transaction($this->orm);
+        $tr->persist($fetchedRole);
+        $tr->run();
     }
 }


### PR DESCRIPTION
Prevent entity state reset caused by repeating hydration call when loading MtM relation