### PR TITLE
Sync with ORM v1 fixes

### DIFF
--- a/src/ORM.php
+++ b/src/ORM.php
@@ -81,7 +81,7 @@ final class ORM implements ORMInterface
                 // todo: redesign
                 // temporary solution for proxy objects
                 $parentClass = get_parent_class($entity);
-                if (substr($parentClass, -6) === ' Proxy' && !$this->schema->defines($parentClass)) {
+                if ($parentClass === false || substr($parentClass, -6) === ' Proxy' && !$this->schema->defines($parentClass)) {
                     throw new ORMException("Unable to resolve role of `$class`.");
                 }
                 $class = $parentClass;

--- a/src/Relation/ManyToMany.php
+++ b/src/Relation/ManyToMany.php
@@ -131,7 +131,7 @@ class ManyToMany extends Relation\AbstractRelation
         $elements = [];
         $pivotData = new SplObjectStorage();
 
-        $iterator = new Iterator($this->orm, $this->target, $data);
+        $iterator = new Iterator($this->orm, $this->target, $data, true);
         foreach ($iterator as $pivot => $entity) {
             if (!is_array($pivot)) {
                 // skip partially selected entities (DB level filter)
@@ -269,7 +269,7 @@ class ManyToMany extends Relation\AbstractRelation
 
         $elements = [];
         $pivotData = new SplObjectStorage();
-        foreach (new Iterator($this->orm, $this->target, $root->getResult()[0]['output']) as $pivot => $entity) {
+        foreach (new Iterator($this->orm, $this->target, $root->getResult()[0]['output'], true) as $pivot => $entity) {
             $pivotData[$entity] = $this->orm->make(
                 $this->schema[Relation::THROUGH_ENTITY],
                 $pivot,

--- a/tests/ORM/Fixtures/RbacItemAbstract.php
+++ b/tests/ORM/Fixtures/RbacItemAbstract.php
@@ -14,6 +14,9 @@ class RbacItemAbstract
      */
     public $name;
 
+    /** @var string|null */
+    public $description;
+
     /**
      * @var DoctrineCollection|RbacRole[]|RbacPermission[]
      * @phpstan-var DoctrineCollection<string,RbacRole|RbacPermission>
@@ -26,9 +29,10 @@ class RbacItemAbstract
      */
     public $children;
 
-    public function __construct(string $name)
+    public function __construct(string $name, string $description = null)
     {
         $this->name = $name;
+        $this->description = $description;
 
         $this->parents = new ArrayCollection();
         $this->children = new ArrayCollection();

--- a/tests/ORM/ManyToManySingleEntityTest.php
+++ b/tests/ORM/ManyToManySingleEntityTest.php
@@ -25,6 +25,7 @@ abstract class ManyToManySingleEntityTest extends BaseTest
 
         $this->makeTable('rbac_item', [
             'name' => 'string,primary',
+            'description' => 'string,nullable',
             '_type' => 'string,nullable',
         ]);
 
@@ -48,7 +49,7 @@ abstract class ManyToManySingleEntityTest extends BaseTest
                 Schema::DATABASE => 'default',
                 Schema::TABLE => 'rbac_item',
                 Schema::PRIMARY_KEY => 'name',
-                Schema::COLUMNS => ['name', '_type'],
+                Schema::COLUMNS => ['name', 'description', '_type'],
                 Schema::RELATIONS => [
                     'parents' => [
                         Relation::TYPE => Relation::MANY_TO_MANY,
@@ -146,12 +147,42 @@ abstract class ManyToManySingleEntityTest extends BaseTest
         $this->save($fetchedRole);
 
         $fetchedRole->children->add($fetchedPermission);
-        // todo Failed with error `Call to undefined method Cycle\ORM\Reference\Reference::add()`
         // Should be solved with proxy task
         $fetchedPermission->parents->add($fetchedRole);
 
         $this->save($fetchedRole);
 
         self::assertTrue(true);
+    }
+
+    public function testNotTriggersRehydrate(): void
+    {
+        $role = new RbacRole('superAdmin', 'description');
+
+        $permission = new RbacPermission('writeUser');
+
+        $role->children->add($permission);
+        $permission->parents->add($role);
+
+        $this->save($role);
+
+        unset($role, $permission);
+
+        $this->orm = $this->orm->withHeap(new Heap());
+
+        /** @var RbacRole $fetchedRole */
+        $fetchedRole = (new Select($this->orm, 'rbac_item'))->wherePK('superAdmin')->fetchOne();
+        /** @var RbacPermission $fetchedPermission */
+        $fetchedPermission = (new Select($this->orm, 'rbac_item'))->wherePK('writeUser')->fetchOne();
+
+        $fetchedRole->description = 'updated description';
+
+        // unlink
+        $fetchedRole->children->removeElement($fetchedPermission);
+        $fetchedPermission->parents->removeElement($fetchedRole);
+
+        self::assertSame('updated description', $fetchedRole->description);
+
+        $this->orm = $this->orm->withHeap(new Heap());
     }
 }

--- a/tests/ORM/Morphed/BelongsToMorphedRelationTest.php
+++ b/tests/ORM/Morphed/BelongsToMorphedRelationTest.php
@@ -336,6 +336,7 @@ abstract class BelongsToMorphedRelationTest extends BaseTest
         $schemaArray[Post::class][Schema::RELATIONS]['image'][Relation::SCHEMA][Relation::NULLABLE] = true;
         return $schemaArray;
     }
+
     private function getSchemaArray(): array
     {
         return [
@@ -354,8 +355,8 @@ abstract class BelongsToMorphedRelationTest extends BaseTest
                         Relation::SCHEMA => [
                             Relation::CASCADE   => true,
                             Relation::INNER_KEY => 'id',
-                            Relation::OUTER_KEY => 'parent_id',
-                            Relation::MORPH_KEY => 'parent_type'
+                            Relation::OUTER_KEY => 'parentId',
+                            Relation::MORPH_KEY => 'parentType'
                         ],
                     ],
                     'posts' => [
@@ -384,8 +385,8 @@ abstract class BelongsToMorphedRelationTest extends BaseTest
                         Relation::SCHEMA => [
                             Relation::CASCADE   => true,
                             Relation::INNER_KEY => 'id',
-                            Relation::OUTER_KEY => 'parent_id',
-                            Relation::MORPH_KEY => 'parent_type'
+                            Relation::OUTER_KEY => 'parentId',
+                            Relation::MORPH_KEY => 'parentType'
                         ],
                     ]
                 ]
@@ -396,7 +397,12 @@ abstract class BelongsToMorphedRelationTest extends BaseTest
                 Schema::DATABASE    => 'default',
                 Schema::TABLE       => 'image',
                 Schema::PRIMARY_KEY => 'id',
-                Schema::COLUMNS     => ['id', 'parent_id', 'parent_type', 'url'],
+                Schema::COLUMNS     => [
+                    'id' => 'id',
+                    'parentId' => 'parent_id',
+                    'parentType' => 'parent_type',
+                    'url' => 'url',
+                ],
                 Schema::SCHEMA      => [],
                 Schema::RELATIONS   => [
                     'parent' => [
@@ -408,8 +414,8 @@ abstract class BelongsToMorphedRelationTest extends BaseTest
                             Relation::NULLABLE  => true,
                             Relation::CASCADE   => true,
                             Relation::OUTER_KEY => 'id',
-                            Relation::INNER_KEY => 'parent_id',
-                            Relation::MORPH_KEY => 'parent_type'
+                            Relation::INNER_KEY => 'parentId',
+                            Relation::MORPH_KEY => 'parentType'
                         ],
                     ]
                 ]


### PR DESCRIPTION
- Prevent repeating entity hydration in MtM relation
- Rename db fields in the test case `BelongsToMorphedRelationTest`