### PR TITLE
Fix psalm error in `DatabaseMapper` 

### DIFF
--- a/src/Mapper/DatabaseMapper.php
+++ b/src/Mapper/DatabaseMapper.php
@@ -23,7 +23,7 @@ abstract class DatabaseMapper implements MapperInterface
 {
     protected SourceInterface $source;
 
-    protected array $columns;
+    protected array $columns = [];
 
     protected array $parentColumns = [];
 


### PR DESCRIPTION
Without this fix in my custom mapper in application psalm show error:

`ERROR: PropertyNotSetInConstructor - MyCustomMapper.php:14:13 - Property MyCustomMapper::$columns is not defined in constructor of MyCustomMapper or in any private or final methods called in the constructor (see https://psalm.dev/074)
final class MyCustomMapper extends Cycle\ORM\Mapper\Mapper`