### PR TITLE
[bugfix]: clone object value in transactionData

### DIFF
--- a/src/Heap/State.php
+++ b/src/Heap/State.php
@@ -18,6 +18,8 @@ use Cycle\ORM\Heap\Traits\ClaimTrait;
 use Cycle\ORM\Heap\Traits\RelationTrait;
 use Cycle\ORM\Heap\Traits\VisitorTrait;
 
+use function is_object;
+
 /**
  * Current node state.
  */
@@ -184,7 +186,7 @@ final class State implements ConsumerInterface, ProducerInterface
         }
 
         if (!array_key_exists($key, $this->transactionData)) {
-            $this->transactionData[$key] = $value;
+            $this->transactionData[$key] = is_object($value) ? clone $value : $value;
         }
 
         $this->data[$key] = $value;

--- a/tests/ORM/StateTest.php
+++ b/tests/ORM/StateTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Cycle\ORM\Tests;
 
 use Cycle\ORM\Heap\Node;
+use Cycle\ORM\Tests\Fixtures\UserCredentials;
 use PHPUnit\Framework\TestCase;
 
 class StateTest extends TestCase
@@ -23,6 +24,25 @@ class StateTest extends TestCase
         $s->register('user_id', 1);
 
         $this->assertSame(1, $s->getData()['user_id']);
+    }
+
+    public function testTransactionData(): void
+    {
+        $credentials = new UserCredentials();
+        $credentials->username = 'test';
+        $credentials->password = 'hash';
+
+        $s = new Node(Node::MANAGED, [], 'parent');
+
+        $s->register('credentials', $credentials);
+
+        $credentials->username = 'test_changed';
+        $credentials->password = 'hash_changed';
+
+        $transactionData = $s->getState()->getTransactionData();
+
+        $this->assertSame('test', $transactionData['credentials']->username);
+        $this->assertSame('hash', $transactionData['credentials']->password);
     }
 
     public function testForward(): void


### PR DESCRIPTION
<table role="table">
<thead>
<tr>
<th>Q</th>
<th>A</th>
</tr>
</thead>
<tbody>
<tr>
<td>Branch?</td>
<td>master</td>
</tr>
<tr>
<td>Bug fix?</td>
<td>yes</td>
</tr>
<tr>
<td>New feature?</td>
<td>no</td>
</tr>
<tr>
<td>Deprecations?</td>
<td>no</td>
</tr>
<tr>
<td>Tickets</td>
<td>#226</td>
</tr>
</tbody>
</table>