### PR TITLE
Removes todo for ProxyEntityFactory::entityToArray method.

### DIFF
--- a/src/Mapper/Proxy/ProxyEntityFactory.php
+++ b/src/Mapper/Proxy/ProxyEntityFactory.php
@@ -177,9 +177,9 @@ class ProxyEntityFactory
     /**
      * Gets property map (primitive fields, relations) for given Entity.
      *
-     * @return PropertyMap[]
-     *
      * @throws \ReflectionException
+     *
+     * @return PropertyMap[]
      */
     private function getEntityProperties(object $entity, RelationMap $relMap): array
     {


### PR DESCRIPTION
Adds phpDoc

Note: there is no needs to work with relations in this method. It's responsible only for entity defined column properties except proxy entity system properties. ProxyEntityFactory::extractRelations is responsible for relations.