### PR TITLE
Fix nested relation persistence

### DIFF
--- a/src/Relation/BelongsTo.php
+++ b/src/Relation/BelongsTo.php
@@ -89,13 +89,13 @@ class BelongsTo extends AbstractRelation implements DependencyInterface
         $node = $tuple->node;
         $related = $tuple->state->getRelation($this->getName());
 
-        if ($related === null) {
-            $this->setNullFromRelated($tuple, false);
-            return;
-        }
         if ($related instanceof ReferenceInterface && $related->hasValue()) {
             $related = $related->getValue();
             $tuple->state->setRelation($this->getName(), $related);
+        }
+        if ($related === null) {
+            $this->setNullFromRelated($tuple, false);
+            return;
         }
         if ($related instanceof ReferenceInterface) {
             $scope = $related->getScope();

--- a/tests/ORM/Fixtures/Image.php
+++ b/tests/ORM/Fixtures/Image.php
@@ -7,6 +7,7 @@ namespace Cycle\ORM\Tests\Fixtures;
 
 class Image
 {
+    public $id;
     public $parent;
 
     public $url;

--- a/tests/ORM/Functional/Driver/Common/Relation/ExistingNestedRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/ExistingNestedRelationTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Relation;
+
+use Cycle\ORM\Heap\Heap;
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\Relation;
+use Cycle\ORM\Schema;
+use Cycle\ORM\Select;
+use Cycle\ORM\Tests\Fixtures\Image;
+use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
+use Cycle\ORM\Tests\Fixtures\Comment;
+use Cycle\ORM\Tests\Fixtures\User;
+use Cycle\ORM\Tests\Traits\TableTrait;
+use Cycle\ORM\Transaction;
+
+abstract class ExistingNestedRelationTest extends BaseTest
+{
+    use TableTrait;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->makeTable('user', [
+            'id' => 'primary',
+            'email' => 'string',
+            'balance' => 'float',
+            'image_id' => 'integer,nullable',
+        ]);
+
+        $this->makeTable('image', [
+            'id' => 'primary',
+            'parent' => 'string',
+            'url' => 'string',
+        ]);
+
+        $this->makeTable('comment', [
+            'id' => 'primary',
+            'user_id' => 'integer',
+            'message' => 'string',
+        ], [
+            'user_id' => ['table' => 'user', 'column' => 'id'],
+        ]);
+
+        $this->makeFK('user', 'image_id', 'image', 'id');
+        $this->makeFK('comment', 'user_id', 'user', 'id');
+
+        $this->orm = $this->withSchema(new Schema([
+            Image::class => [
+                Schema::ROLE => 'image',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'image',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'parent', 'url'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [],
+            ],
+            User::class => [
+                Schema::ROLE => 'user',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'user',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'email', 'balance', 'image_id'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [
+                    'image' => [
+                        Relation::TYPE => Relation::BELONGS_TO,
+                        Relation::TARGET => Image::class,
+                        Relation::LOAD => Relation::LOAD_PROMISE,
+                        Relation::SCHEMA => [
+                            Relation::CASCADE => true,
+                            Relation::INNER_KEY => 'image_id',
+                            Relation::OUTER_KEY => 'id',
+                            Relation::NULLABLE => true,
+                        ],
+                    ],
+                    'comments' => [
+                        Relation::TYPE => Relation::HAS_MANY,
+                        Relation::TARGET => Comment::class,
+                        Relation::SCHEMA => [
+                            Relation::CASCADE => true,
+                            Relation::INNER_KEY => 'id',
+                            Relation::OUTER_KEY => 'user_id',
+                        ],
+                    ],
+                ],
+            ],
+            Comment::class => [
+                Schema::ROLE => 'comment',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'comment',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'user_id', 'message'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [
+                    'user' => [
+                        Relation::TYPE => Relation::BELONGS_TO,
+                        Relation::TARGET => User::class,
+                        Relation::SCHEMA => [
+                            Relation::CASCADE => true,
+                            Relation::INNER_KEY => 'user_id',
+                            Relation::OUTER_KEY => 'id',
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+    }
+
+    public function testCreateForExisting(): void
+    {
+        $u = new User();
+        $u->email = 'test@email.com';
+        $u->balance = 1000;
+
+        $this->captureWriteQueries();
+
+        $tr = new Transaction($this->orm);
+        $tr->persist($u);
+        $tr->run();
+
+        $this->assertNumWrites(1);
+
+        $this->orm = $this->orm->withHeap(new Heap());
+
+        $selector = new Select($this->orm, User::class);
+        /** @var User $u */
+        $u = $selector->wherePK($u->id)->fetchOne();
+
+        $c = new Comment();
+        $c->user = $u;
+        $c->message = 'hello world';
+
+        $u->addComment($c);
+
+        $this->captureWriteQueries();
+        $tr = new Transaction($this->orm);
+        $tr->persist($u);
+        $tr->run();
+        $this->assertNumWrites(1);
+    }
+}

--- a/tests/ORM/Functional/Driver/MySQL/Relation/ExistingNestedRelationTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Relation/ExistingNestedRelationTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\MySQL\Relation;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\ExistingNestedRelationTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class ExistingNestedRelationTest extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/ORM/Functional/Driver/Postgres/Relation/ExistingNestedRelationTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Relation/ExistingNestedRelationTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Postgres\Relation;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\ExistingNestedRelationTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class ExistingNestedRelationTest extends CommonClass
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/ORM/Functional/Driver/SQLServer/Relation/ExistingNestedRelationTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Relation/ExistingNestedRelationTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLServer\Relation;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\ExistingNestedRelationTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class ExistingNestedRelationTest extends CommonClass
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/ORM/Functional/Driver/SQLite/Relation/ExistingNestedRelationTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Relation/ExistingNestedRelationTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLite\Relation;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\ExistingNestedRelationTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class ExistingNestedRelationTest extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+}


### PR DESCRIPTION
When we have a belongsTo relation that has its own belongsTo relation that is null, persisting it will fail because `$related instanceof ReferenceInterface && $related->hasValue()` will return true, BUT the actual value inside is NULL.

Suggested change first unwraps the reference and if it's NULL, resets it. This later allows to avoid getting TypeError when calling `$rTuple = $pool->offsetGet($related);` where we pass NULL to a method that expects to receive object.