### PR TITLE
Extract `origin` in the `HasMany::queue()` when it's instance of Collection

### DIFF
--- a/src/Relation/HasMany.php
+++ b/src/Relation/HasMany.php
@@ -102,6 +102,10 @@ class HasMany extends AbstractRelation
             $original = $this->resolve($original);
         }
 
+        if ($original instanceof Collection) {
+            $original = $original->toArray();
+        }
+
         $sequence = new Sequence();
 
         foreach ($related as $item) {

--- a/tests/ORM/HasManyRelationTest.php
+++ b/tests/ORM/HasManyRelationTest.php
@@ -285,6 +285,22 @@ abstract class HasManyRelationTest extends BaseTest
         ], $selector->wherePK(3)->fetchData());
     }
 
+    public function testSetCollectionDirectlyInNodeRelation(): void
+    {
+        $e = (new Select($this->orm, User::class))
+            ->orderBy('user.id', 'desc')
+            ->load('comments')
+            ->fetchOne();
+
+        $node = $this->orm->getHeap()->get($e);
+        // Anti-pattern. Don't do that!
+        $node->setRelation('comments', new ArrayCollection([]));
+
+        $this->captureWriteQueries();
+        $this->save($e);
+        $this->assertNumWrites(0);
+    }
+
     public function testRemoveChildren(): void
     {
         $selector = new Select($this->orm, User::class);


### PR DESCRIPTION
I was not able to write a test case for this error.

```
TypeError: Argument 2 passed to Cycle\ORM\Relation\HasMany::calcDeleted() must be of the type array, object given,
called in /vendor/cycle/orm/src/Relation/HasMany.php on line 111
in /vendor/cycle/orm/src/Relation/HasMany.php at line 126
```