### PR TITLE
[STI] fix get from Repository if parent entity `_type` column not defined

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -141,6 +141,11 @@ final class Schema implements SchemaInterface
                 $aliases[$item[self::ENTITY]] = $role;
             }
 
+            // Single Table Inheritance marker
+            if (isset($item[self::CHILDREN]) && !isset($item[self::COLUMNS]['_type'])) {
+                $item[self::COLUMNS]['_type'] = '_type';
+            }
+
             unset($item[self::ROLE]);
             $result[$role] = $item;
         }

--- a/tests/ORM/Driver/MySQL/TableInheritanceWithoutTypeColumnTest.php
+++ b/tests/ORM/Driver/MySQL/TableInheritanceWithoutTypeColumnTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Driver\MySQL;
+
+class TableInheritanceWithoutTypeColumnTest extends \Cycle\ORM\Tests\TableInheritanceWithoutTypeColumnTest
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/ORM/Driver/Postgres/TableInheritanceWithoutTypeColumnTest.php
+++ b/tests/ORM/Driver/Postgres/TableInheritanceWithoutTypeColumnTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Driver\Postgres;
+
+class TableInheritanceWithoutTypeColumnTest extends \Cycle\ORM\Tests\TableInheritanceWithoutTypeColumnTest
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/ORM/Driver/SQLServer/TableInheritanceWithoutTypeColumnTest.php
+++ b/tests/ORM/Driver/SQLServer/TableInheritanceWithoutTypeColumnTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Driver\SQLServer;
+
+class TableInheritanceWithoutTypeColumnTest extends \Cycle\ORM\Tests\TableInheritanceWithoutTypeColumnTest
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/ORM/Driver/SQLite/TableInheritanceWithoutTypeColumnTest.php
+++ b/tests/ORM/Driver/SQLite/TableInheritanceWithoutTypeColumnTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Driver\SQLite;
+
+class TableInheritanceWithoutTypeColumnTest extends \Cycle\ORM\Tests\TableInheritanceWithoutTypeColumnTest
+{
+    public const DRIVER = 'sqlite';
+}

--- a/tests/ORM/TableInheritanceWithoutTypeColumnTest.php
+++ b/tests/ORM/TableInheritanceWithoutTypeColumnTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests;
+
+use Cycle\ORM\Heap\Heap;
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\Schema;
+use Cycle\ORM\Select;
+use Cycle\ORM\Tests\Fixtures\Admin;
+use Cycle\ORM\Tests\Fixtures\User;
+use Cycle\ORM\Tests\Traits\TableTrait;
+use Cycle\ORM\Transaction;
+
+/**
+ * Copy of TableInheritanceTest without defined User `_type` schema column.
+ * In case the SchemaBuilder did not generate the "_type" property.
+ */
+abstract class TableInheritanceWithoutTypeColumnTest extends BaseTest
+{
+    use TableTrait;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->makeTable('user', [
+            'id'          => 'primary',
+            '_type'       => 'string,nullable',
+            'email'       => 'string',
+            'balance'     => 'float',
+            'permissions' => 'string,nullable',
+        ]);
+
+        $this->getDatabase()->table('user')->insertMultiple(
+            ['_type', 'email', 'balance', 'permissions'],
+            [
+                ['user', 'hello@world.com', 100, ''],
+                ['admin', 'another@world.com', 200, '*'],
+                [null, 'third@world.com', 300, ''],
+            ]
+        );
+
+        $this->orm = $this->withSchema(new Schema([
+            User::class  => [
+                Schema::ROLE        => 'user',
+                Schema::CHILDREN    => [
+                    'admin' => Admin::class,
+                ],
+                Schema::MAPPER      => Mapper::class,
+                Schema::DATABASE    => 'default',
+                Schema::TABLE       => 'user',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS     => ['id', 'email', 'balance', 'permissions'],
+                Schema::SCHEMA      => [],
+                Schema::RELATIONS   => [],
+            ],
+            Admin::class => [Schema::ROLE => User::class],
+        ]));
+    }
+
+    public function testFetchData(): void
+    {
+        $selector = new Select($this->orm, User::class);
+
+        $this->assertEquals([
+            [
+                'id'          => 1,
+                '_type'       => 'user',
+                'email'       => 'hello@world.com',
+                'balance'     => 100.0,
+                'permissions' => '',
+            ],
+            [
+                'id'          => 2,
+                '_type'       => 'admin',
+                'email'       => 'another@world.com',
+                'balance'     => 200.0,
+                'permissions' => '*',
+            ],
+            [
+                'id'          => 3,
+                '_type'       => null,
+                'email'       => 'third@world.com',
+                'balance'     => 300.0,
+                'permissions' => '',
+            ],
+        ], $selector->fetchData());
+    }
+
+    public function testIterate(): void
+    {
+        $selector = new Select($this->orm, User::class);
+        [$a, $b, $c] = $selector->orderBy('id')->fetchAll();
+
+        $this->assertInstanceOf(User::class, $a);
+        $this->assertNotInstanceOf(Admin::class, $a);
+        $this->assertInstanceOf(Admin::class, $b);
+        $this->assertInstanceOf(User::class, $c);
+        $this->assertNotInstanceOf(Admin::class, $c);
+
+        $this->assertSame('*', $b->permissions);
+    }
+
+    public function testStoreNormalAndInherited(): void
+    {
+        $u = new User();
+        $u->email = 'user@email.com';
+        $u->balance = 100;
+
+        $a = new Admin();
+        $a->email = 'admin@email.com';
+        $a->balance = 400;
+        $a->permissions = '~';
+
+        $tr = new Transaction($this->orm);
+        $tr->persist($u);
+        $tr->persist($a);
+        $tr->run();
+
+        $selector = new Select($this->orm->withHeap(new Heap()), User::class);
+        $this->assertInstanceOf(User::class, $selector->wherePK(4)->fetchOne());
+
+        $selector = new Select($this->orm->withHeap(new Heap()), User::class);
+        $this->assertNotInstanceOf(Admin::class, $selector->wherePK(4)->fetchOne());
+
+        $selector = new Select($this->orm->withHeap(new Heap()), User::class);
+        $this->assertInstanceOf(Admin::class, $selector->wherePK(5)->fetchOne());
+    }
+
+    public function testGetFromRepositoryWithEmptyHeap(): void
+    {
+        $u = new User();
+        $u->email = 'user@email.com';
+        $u->balance = 100;
+
+        $a = new Admin();
+        $a->email = 'admin@email.com';
+        $a->balance = 400;
+        $a->permissions = '~';
+
+        $tr = new Transaction($this->orm);
+        $tr->persist($u);
+        $tr->persist($a);
+        $tr->run();
+        unset($u, $a);
+
+        $this->orm->getHeap()->clean();
+
+        $u = $this->orm->get(User::class, ['id' => 4]);
+        self::assertInstanceOf(User::class, $u);
+        $a = $this->orm->get(User::class, ['id' => 5]);
+        self::assertInstanceOf(Admin::class, $a);
+    }
+}


### PR DESCRIPTION
SchemaBuilder not generates `_type` column fro STI parent while executing `cycle:sync` command.

Because of this, you can't get child class instance from Orm repository.

![image](https://user-images.githubusercontent.com/3841197/144900140-60300e81-3cde-490e-9edd-44db85d1c119.png)
