### PR TITLE
Removing $config property override

### DIFF
--- a/src/Config/RelationConfig.php
+++ b/src/Config/RelationConfig.php
@@ -17,9 +17,6 @@ final class RelationConfig extends InjectableConfig
     public const RELATION = 'relation';
     public const SCHEMA = 'schema';
 
-    /** @var array */
-    protected $config = [];
-
     public function getLoader(int|string $type): Autowire
     {
         if (!isset($this->config[$type][self::LOADER])) {


### PR DESCRIPTION
This property is already declared in the base class and is typed in v3.0.x-dev:
https://github.com/spiral/framework/blob/3.0/src/Core/src/InjectableConfig.php#L25

This causes a fatal error.