### PR TITLE
Hotfix: `EM::persistState` inserts the same entity twice

### DIFF
--- a/src/Heap/Node.php
+++ b/src/Heap/Node.php
@@ -66,7 +66,7 @@ final class Node
      */
     public function createState(): State
     {
-        return $this->state = new State($this->status, $this->data, $this->rawData);
+        return $this->state ??= new State($this->status, $this->data, $this->rawData);
     }
 
     /**

--- a/tests/ORM/Functional/Driver/Common/EntityManager/EntityManagerTest.php
+++ b/tests/ORM/Functional/Driver/Common/EntityManager/EntityManagerTest.php
@@ -157,6 +157,28 @@ abstract class EntityManagerTest extends BaseTest
         $this->assertSame('changed title', $entity->title);
     }
 
+    /**
+     * @link https://github.com/cycle/orm/issues/355
+     */
+    public function testPersistStateTwice(): void
+    {
+        $em = new EntityManager($this->orm);
+
+        $entity = $this->orm->make(Post::class, [
+            'title' => 'Test title',
+            'content' => 'Test content',
+        ]);
+
+        $this->captureWriteQueries();
+        $em->persistState($entity)->run();
+        $this->assertNumWrites(1);
+        $this->assertNotNull($entity->id);
+
+        $this->captureWriteQueries();
+        $em->persistState($entity)->run();
+        $this->assertNumWrites(0);
+    }
+
     public function testRunException(): void
     {
         $em = new EntityManager($this->orm);


### PR DESCRIPTION
Fixes #355

- [x] Add test case
- [x] Make a fix
