### PR TITLE
JTI child entity do not insert embedded relations

### DIFF
--- a/tests/ORM/Functional/Driver/Common/Inheritance/Fixture/ManagerWithCredentials.php
+++ b/tests/ORM/Functional/Driver/Common/Inheritance/Fixture/ManagerWithCredentials.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Inheritance\Fixture;
+
+use Cycle\ORM\Tests\Fixtures\UserCredentials;
+
+class ManagerWithCredentials extends Employee
+{
+    public ?int $role_id = null;
+
+    public ?int $level = null;
+    public string $rank = 'none';
+    public ?UserCredentials $credentials = null;
+}

--- a/tests/ORM/Functional/Driver/Common/Inheritance/JTI/Relation/EmbeddedRelationsTest.php
+++ b/tests/ORM/Functional/Driver/Common/Inheritance/JTI/Relation/EmbeddedRelationsTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Inheritance\JTI\Relation;
+
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\Relation;
+use Cycle\ORM\SchemaInterface;
+use Cycle\ORM\Select;
+use Cycle\ORM\Tests\Fixtures\UserCredentials;
+use Cycle\ORM\Tests\Functional\Driver\Common\Inheritance\Fixture\Employee;
+use Cycle\ORM\Tests\Functional\Driver\Common\Inheritance\Fixture\Manager;
+use Cycle\ORM\Tests\Functional\Driver\Common\Inheritance\Fixture\ManagerWithCredentials;
+use Cycle\ORM\Tests\Functional\Driver\Common\Inheritance\JTI\JtiBaseTest;
+
+abstract class EmbeddedRelationsTest extends JtiBaseTest
+{
+    protected const EMPLOYEE_ROLE = 'employee';
+    protected const MANAGER_ROLE = 'manager_with_credentials';
+
+    protected const EMPLOYEE_1 = ['id' => 1, 'name' => 'John', 'age' => 38];
+    protected const EMPLOYEE_2 = ['id' => 2, 'name' => 'Anton', 'age' => 35];
+    protected const EMPLOYEE_3 = ['id' => 3, 'name' => 'Kentarius', 'age' => 27];
+    protected const EMPLOYEE_4 = ['id' => 4, 'name' => 'Valeriy', 'age' => 32];
+    protected const MANAGER_1 = ['id' => 1, 'rank' => 'top'];
+    protected const MANAGER_3 = ['id' => 3, 'rank' => 'bottom'];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->makeTable('employee', [
+            'id' => 'integer',
+            'name' => 'string',
+            'age' => 'integer,nullable',
+        ], pk: ['id']);
+
+        $this->makeTable('manager_with_credentials', [
+            'id' => 'integer',
+            'rank' => 'string',
+            'creds_username' => 'string,nullable',
+            'creds_password' => 'string,nullable',
+        ], fk: [
+            'id' => ['table' => 'employee', 'column' => 'id'],
+        ], pk: ['id']);
+
+        $this->getDatabase()->table('employee')->insertMultiple(
+            array_keys(static::EMPLOYEE_1),
+            [
+                self::EMPLOYEE_1,
+                self::EMPLOYEE_2,
+                self::EMPLOYEE_3,
+                self::EMPLOYEE_4,
+            ]
+        );
+        $this->getDatabase()->table('manager_with_credentials')->insertMultiple(
+            array_keys(static::MANAGER_1),
+            [
+                self::MANAGER_1,
+                self::MANAGER_3,
+            ]
+        );
+    }
+
+    /**
+     * Parent's relation should be initialized
+     */
+    public function testInsertToEmbeddedFieldsForJtiChildEntity(): void
+    {
+        /** @var ManagerWithCredentials $entity */
+        $entity = (new Select($this->orm, self::MANAGER_ROLE))
+            ->wherePK(1)
+            ->fetchOne();
+
+        $credentials = new UserCredentials();
+        $credentials->username = 'roquie';
+        $credentials->password = 'secret';
+
+        $entity->credentials = $credentials;
+
+        $this->save($entity);
+
+        $entity = (new Select($this->orm, self::MANAGER_ROLE))
+            ->wherePK(1)
+            ->fetchOne();
+
+        $this->assertNotNull($entity->credentials->username);
+        $this->assertNotNull($entity->credentials->password);
+    }
+
+    protected function getSchemaArray(): array
+    {
+        return [
+            static::EMPLOYEE_ROLE => [
+                SchemaInterface::ENTITY => Employee::class,
+                SchemaInterface::MAPPER => static::DEFAULT_MAPPER,
+                SchemaInterface::DATABASE => 'default',
+                SchemaInterface::TABLE => 'employee',
+                SchemaInterface::PRIMARY_KEY => 'id',
+                SchemaInterface::COLUMNS => ['id', 'name', 'age'],
+                SchemaInterface::TYPECAST => ['id' => 'int', 'age' => 'int'],
+                SchemaInterface::SCHEMA => [],
+                SchemaInterface::RELATIONS => [],
+            ],
+            static::MANAGER_ROLE => [
+                SchemaInterface::ENTITY => Manager::class,
+                SchemaInterface::MAPPER => static::DEFAULT_MAPPER,
+                SchemaInterface::DATABASE => 'default',
+                SchemaInterface::TABLE => 'manager_with_credentials',
+                SchemaInterface::PARENT => static::EMPLOYEE_ROLE,
+                SchemaInterface::PRIMARY_KEY => 'id',
+                SchemaInterface::COLUMNS => ['id', 'rank'],
+                SchemaInterface::TYPECAST => ['id' => 'int'],
+                SchemaInterface::SCHEMA => [],
+                SchemaInterface::RELATIONS => [
+                    'credentials' => [
+                        Relation::TYPE => Relation::EMBEDDED,
+                        Relation::TARGET => 'user:credentials',
+                        Relation::LOAD => Relation::LOAD_EAGER,
+                        Relation::SCHEMA => [],
+                    ],
+                ],
+            ],
+            UserCredentials::class => [
+                SchemaInterface::ROLE => 'user:credentials',
+                SchemaInterface::ENTITY => UserCredentials::class,
+                SchemaInterface::MAPPER => Mapper::class,
+                SchemaInterface::DATABASE => 'default',
+                SchemaInterface::TABLE => 'manager_with_credentials',
+                SchemaInterface::PRIMARY_KEY => 'id',
+                SchemaInterface::COLUMNS => [
+                    'id' => 'id',
+                    'username' => 'creds_username',
+                    'password' => 'creds_password',
+                ],
+                SchemaInterface::SCHEMA => [],
+                SchemaInterface::TYPECAST => ['id' => 'int'],
+                SchemaInterface::RELATIONS => [],
+            ],
+        ];
+    }
+}

--- a/tests/ORM/Functional/Driver/MySQL/Inheritance/JTI/Relation/EmbeddedRelationsTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Inheritance/JTI/Relation/EmbeddedRelationsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\MySQL\Inheritance\JTI\Relation;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Inheritance\JTI\Relation\EmbeddedRelationsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class EmbeddedRelationsTest extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/ORM/Functional/Driver/Postgres/Inheritance/JTI/Relation/EmbeddedRelationsTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Inheritance/JTI/Relation/EmbeddedRelationsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Postgres\Inheritance\JTI\Relation;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Inheritance\JTI\Relation\EmbeddedRelationsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class EmbeddedRelationsTest extends CommonClass
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/ORM/Functional/Driver/SQLServer/Inheritance/JTI/Relation/EmbeddedRelationsTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Inheritance/JTI/Relation/EmbeddedRelationsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLServer\Inheritance\JTI\Relation;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Inheritance\JTI\Relation\EmbeddedRelationsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class EmbeddedRelationsTest extends CommonClass
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/ORM/Functional/Driver/SQLite/Inheritance/JTI/Relation/EmbeddedRelationsTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Inheritance/JTI/Relation/EmbeddedRelationsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLite\Inheritance\JTI\Relation;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Inheritance\JTI\Relation\EmbeddedRelationsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class EmbeddedRelationsTest extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+}


### PR DESCRIPTION
We have follow db structure:
1. employee
2. manager_with_credentials

When table `manager_with_credentials` is a parent to `employee` table (classic JTI relation). 

Table `manager_with_credentials` have embedded relation `user:credentials` and I want to insert these credentials to database:

```php
/** @var ManagerWithCredentials $entity */
$entity = (new Select($this->orm, self::MANAGER_ROLE))
    ->wherePK(1)
    ->fetchOne();

$credentials = new UserCredentials();
$credentials->username = 'roquie';
$credentials->password = 'secret';

$entity->credentials = $credentials;

$this->save($entity);

$entity = (new Select($this->orm, self::MANAGER_ROLE))
    ->wherePK(1)
    ->fetchOne();

$this->assertNotNull($entity->credentials->username); // fails
$this->assertNotNull($entity->credentials->password); // fails
```

... but I can't.