### PR TITLE
JTI filter by parent fields

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -15,6 +15,7 @@
         <UndefinedAttributeClass>
             <errorLevel type="suppress">
                 <referencedClass name="JetBrains\PhpStorm\ExpectedValues" />
+                <referencedClass name="JetBrains\PhpStorm\Deprecated" />
                 <referencedClass name="JetBrains\PhpStorm\Pure" />
             </errorLevel>
         </UndefinedAttributeClass>

--- a/src/Collection/ArrayCollectionFactory.php
+++ b/src/Collection/ArrayCollectionFactory.php
@@ -30,6 +30,7 @@ use Cycle\ORM\Exception\CollectionFactoryException;
  * </code>
  *
  * @template TCollection of array
+ *
  * @template-implements CollectionFactoryInterface<TCollection>
  */
 final class ArrayCollectionFactory implements CollectionFactoryInterface

--- a/src/Collection/DoctrineCollectionFactory.php
+++ b/src/Collection/DoctrineCollectionFactory.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Collections\Collection;
  * Items and Pivots for `Many to Many` relation stores in {@see PivotedCollection}.
  *
  * @template TCollection of Collection
+ *
  * @template-implements CollectionFactoryInterface<TCollection>
  */
 final class DoctrineCollectionFactory implements CollectionFactoryInterface

--- a/src/Collection/IlluminateCollectionFactory.php
+++ b/src/Collection/IlluminateCollectionFactory.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 
 /**
  * @template TCollection of Collection
+ *
  * @template-implements CollectionFactoryInterface<TCollection>
  */
 final class IlluminateCollectionFactory implements CollectionFactoryInterface

--- a/src/Collection/LoophpCollectionFactory.php
+++ b/src/Collection/LoophpCollectionFactory.php
@@ -9,6 +9,7 @@ use loophp\collection\Collection;
 
 /**
  * @template TCollection of Collection
+ *
  * @template-implements CollectionFactoryInterface<TCollection>
  */
 final class LoophpCollectionFactory implements CollectionFactoryInterface

--- a/src/Collection/Pivoted/PivotedCollection.php
+++ b/src/Collection/Pivoted/PivotedCollection.php
@@ -16,6 +16,7 @@ use SplObjectStorage;
  * @psalm-template TPivot of object
  *
  * @template-extends ArrayCollection<TKey, TEntity>
+ *
  * @template-implements PivotedCollectionInterface<TEntity, TPivot>
  */
 class PivotedCollection extends ArrayCollection implements PivotedCollectionInterface

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -46,6 +46,7 @@ final class Factory implements FactoryInterface
 
     /**
      * @var array<string, CollectionFactoryInterface>
+     *
      * @psalm-var array<class-string, CollectionFactoryInterface>
      */
     private array $collectionFactoryInterface = [];

--- a/src/Mapper/Proxy/ClasslessProxyFactory.php
+++ b/src/Mapper/Proxy/ClasslessProxyFactory.php
@@ -13,6 +13,7 @@ class ClasslessProxyFactory
 {
     /**
      * @var string[]
+     *
      * @psalm-var class-string
      */
     private array $classMap = [];

--- a/src/Mapper/Proxy/ProxyEntityFactory.php
+++ b/src/Mapper/Proxy/ProxyEntityFactory.php
@@ -18,6 +18,7 @@ class ProxyEntityFactory
 {
     /**
      * @var string[]
+     *
      * @psalm-var class-string[]
      */
     private array $classMap = [];

--- a/src/ORMInterface.php
+++ b/src/ORMInterface.php
@@ -43,6 +43,7 @@ interface ORMInterface extends
      * @param bool $typecast Indicates that data is raw, and typecasting should be applied.
      *
      * @return TEntity
+     *
      * @psalm-return ($role is class-string ? TEntity : object)
      */
     public function make(string $role, array $data = [], int $status = Node::NEW, bool $typecast = false): object;
@@ -97,6 +98,7 @@ interface ORMInterface extends
      * @param class-string<TEntity>|non-empty-string|TEntity $entity
      *
      * @return RepositoryInterface<TEntity>
+     *
      * @psalm-return ($entity is class-string ? RepositoryInterface<TEntity> : RepositoryInterface)
      */
     public function getRepository(string|object $entity): RepositoryInterface;

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -14,6 +14,7 @@ final class Schema implements SchemaInterface
     private array $aliases;
     /**
      * @var string[]
+     *
      * @psalm-var class-string[]
      */
     private array $classes = [];

--- a/src/Select.php
+++ b/src/Select.php
@@ -450,7 +450,7 @@ class Select implements IteratorAggregate, Countable, PaginableInterface
 
     /**
      * @param list<non-empty-string> $pk
-     * @param list<string|int|array|object> $args
+     * @param list<array|int|object|string> $args
      *
      * @return Select<TEntity>
      */

--- a/src/Select.php
+++ b/src/Select.php
@@ -151,12 +151,12 @@ class Select implements IteratorAggregate, Countable, PaginableInterface
      */
     public function wherePK(string|int|array|object ...$ids): self
     {
-        $pk = $this->loader->getPK();
+        $pk = $this->loader->getPrimaryFields();
 
-        if (\is_array($pk) && \count($pk) > 1) {
+        if (\count($pk) > 1) {
             return $this->buildCompositePKQuery($pk, $ids);
         }
-        $pk = \current((array)$pk);
+        $pk = \current($pk);
 
         return \count($ids) > 1
             ? $this->__call('where', [$pk, new Parameter($ids)])
@@ -449,6 +449,9 @@ class Select implements IteratorAggregate, Countable, PaginableInterface
     }
 
     /**
+     * @param list<non-empty-string> $pk
+     * @param list<string|int|array|object> $args
+     *
      * @return Select<TEntity>
      */
     private function buildCompositePKQuery(array $pk, array $args): self
@@ -467,14 +470,11 @@ class Select implements IteratorAggregate, Countable, PaginableInterface
 
             $isAssoc = !array_is_list($values);
             foreach ($values as $key => $value) {
-                $key = $isAssoc
-                    ? $this->loader->getAlias() . '.' . $this->loader->fieldAlias($key)
-                    : $pk[$key];
-
-                if (!\in_array($key, $pk, true)) {
-                    throw new InvalidArgumentException(\sprintf('Primary key %s not found.', $key));
+                if ($isAssoc && !\in_array($key, $pk, true)) {
+                    throw new InvalidArgumentException(\sprintf('Primary key `%s` not found.', $key));
                 }
 
+                $key = $isAssoc ? $key : $pk[$key];
                 $prepared[$index][$key] = $value;
             }
         }

--- a/src/Select/AbstractLoader.php
+++ b/src/Select/AbstractLoader.php
@@ -302,6 +302,7 @@ abstract class AbstractLoader implements LoaderInterface
 
     /**
      * @deprecated
+     *
      * @codeCoverageIgnore
      */
     #[Deprecated('2.3', '$this->loadHierarchy(%parameter0%, %parameter1%)')]

--- a/src/Select/AbstractLoader.php
+++ b/src/Select/AbstractLoader.php
@@ -17,6 +17,7 @@ use Cycle\ORM\Select\Loader\ParentLoader;
 use Cycle\ORM\Select\Loader\SubclassLoader;
 use Cycle\ORM\Select\Traits\AliasTrait;
 use Cycle\ORM\Select\Traits\ChainTrait;
+use JetBrains\PhpStorm\Deprecated;
 
 /**
  * ORM Loaders used to load an compile data tree based on results fetched from SQL databases,
@@ -279,6 +280,14 @@ abstract class AbstractLoader implements LoaderInterface
     }
 
     /**
+     * Returns inheritance parent loader.
+     */
+    public function getParentLoader(): ?LoaderInterface
+    {
+        return $this->inherit;
+    }
+
+    /**
      * Indicates that loader loads data.
      */
     abstract public function isLoaded(): bool;
@@ -288,10 +297,19 @@ abstract class AbstractLoader implements LoaderInterface
         foreach ($this->load as $relation => $loader) {
             $loader->loadData($node->getNode($relation), $includeRole);
         }
-        $this->loadIerarchy($node, $includeRole);
+        $this->loadHierarchy($node, $includeRole);
     }
 
+    /**
+     * @deprecated
+     */
+    #[Deprecated('2.3',  '$this->loadHierarchy(%parameter0%, %parameter1%)')]
     protected function loadIerarchy(AbstractNode $node, bool $includeRole = false): void
+    {
+        $this->loadHierarchy($node, $includeRole);
+    }
+
+    protected function loadHierarchy(AbstractNode $node, bool $includeRole = false): void
     {
         if ($this->inherit === null && !$this->loadSubclasses) {
             return;

--- a/src/Select/AbstractLoader.php
+++ b/src/Select/AbstractLoader.php
@@ -303,7 +303,7 @@ abstract class AbstractLoader implements LoaderInterface
     /**
      * @deprecated
      */
-    #[Deprecated('2.3',  '$this->loadHierarchy(%parameter0%, %parameter1%)')]
+    #[Deprecated('2.3', '$this->loadHierarchy(%parameter0%, %parameter1%)')]
     protected function loadIerarchy(AbstractNode $node, bool $includeRole = false): void
     {
         $this->loadHierarchy($node, $includeRole);

--- a/src/Select/AbstractLoader.php
+++ b/src/Select/AbstractLoader.php
@@ -302,6 +302,7 @@ abstract class AbstractLoader implements LoaderInterface
 
     /**
      * @deprecated
+     * @codeCoverageIgnore
      */
     #[Deprecated('2.3', '$this->loadHierarchy(%parameter0%, %parameter1%)')]
     protected function loadIerarchy(AbstractNode $node, bool $includeRole = false): void

--- a/src/Select/JoinableLoader.php
+++ b/src/Select/JoinableLoader.php
@@ -67,7 +67,7 @@ abstract class JoinableLoader extends AbstractLoader implements JoinableInterfac
         protected array $schema
     ) {
         parent::__construct($ormSchema, $sourceProvider, $factory, $target);
-        $this->columns = $this->define(SchemaInterface::COLUMNS);
+        $this->columns = $this->normalizeColumns($this->define(SchemaInterface::COLUMNS));
     }
 
     /**

--- a/src/Select/Loader/EmbeddedLoader.php
+++ b/src/Select/Loader/EmbeddedLoader.php
@@ -34,8 +34,8 @@ final class EmbeddedLoader implements JoinableInterface
     ) {
         // never duplicate primary key in data selection
         $primaryKey = (array)$this->define(SchemaInterface::PRIMARY_KEY);
-        foreach ($this->define(SchemaInterface::COLUMNS) as $internal => $external) {
-            if (!in_array($internal, $primaryKey, true) && !in_array($external, $primaryKey, true)) {
+        foreach ($this->normalizeColumns($this->define(SchemaInterface::COLUMNS)) as $internal => $external) {
+            if (!\in_array($internal, $primaryKey, true)) {
                 $this->columns[$internal] = $external;
             }
         }

--- a/src/Select/LoaderInterface.php
+++ b/src/Select/LoaderInterface.php
@@ -28,7 +28,7 @@ interface LoaderInterface
     /**
      * Get column name related to internal key.
      */
-    public function fieldAlias(string $field): string;
+    public function fieldAlias(string $field): ?string;
 
     /**
      * Initiate loader with it's position and options in dependency tree.

--- a/src/Select/QueryBuilder.php
+++ b/src/Select/QueryBuilder.php
@@ -109,21 +109,21 @@ final class QueryBuilder
 
         if (!str_contains($identifier, '.')) {
             // parent element
-            return sprintf(
+            return \sprintf(
                 '%s.%s',
                 $this->loader->getAlias(),
                 $this->loader->fieldAlias($identifier)
             );
         }
 
-        $split = strrpos($identifier, '.');
+        $split = \strrpos($identifier, '.');
 
-        $loader = $this->findLoader(substr($identifier, 0, $split), $autoload);
+        $loader = $this->findLoader(\substr($identifier, 0, $split), $autoload);
         if ($loader !== null) {
-            return sprintf(
+            return \sprintf(
                 '%s.%s',
                 $loader->getAlias(),
-                $loader->fieldAlias(substr($identifier, $split + 1))
+                $loader->fieldAlias(\substr($identifier, $split + 1))
             );
         }
 
@@ -202,7 +202,7 @@ final class QueryBuilder
         }
 
         if ($args[0] instanceof Closure) {
-            $args[0] = $args[0] = function ($q) use ($args): void {
+            $args[0] = function ($q) use ($args): void {
                 $args[0]($this->withQuery($q));
             };
         }
@@ -236,11 +236,12 @@ final class QueryBuilder
         $result = [];
         foreach ($input as $k => $v) {
             if (\is_array($v)) {
-                if (!\is_numeric($k) && \in_array(strtoupper($k), [Compiler::TOKEN_AND, Compiler::TOKEN_OR], true)) {
+                if (!\is_numeric($k) && \in_array(\strtoupper($k), [Compiler::TOKEN_AND, Compiler::TOKEN_OR], true)) {
                     // complex expression like @OR and @AND
                     $result[$k] = $this->walkRecursive($v, $func, true);
                     continue;
                 }
+
                 if ($complex) {
                     $v = $this->walkRecursive($v, $func);
                 }

--- a/src/Select/QueryBuilder.php
+++ b/src/Select/QueryBuilder.php
@@ -108,12 +108,22 @@ final class QueryBuilder
         }
 
         if (!\str_contains($identifier, '.')) {
-            // parent element
-            return \sprintf(
-                '%s.%s',
-                $this->loader->getAlias(),
-                $this->loader->fieldAlias($identifier) ?? $identifier,
-            );
+            $current = $this->loader;
+
+            do {
+                $column = $current->fieldAlias($identifier);
+
+                // Find an inheritance parent that has this field
+                if ($column === null) {
+                    $parent = $current->getParentLoader();
+                    if ($parent !== null) {
+                        $current = $parent;
+                        continue;
+                    }
+                }
+
+                return \sprintf('%s.%s', $current->getAlias(), $column ?? $identifier);
+            } while (true);
         }
 
         $split = \strrpos($identifier, '.');

--- a/src/Select/QueryBuilder.php
+++ b/src/Select/QueryBuilder.php
@@ -107,12 +107,12 @@ final class QueryBuilder
             return '*';
         }
 
-        if (!str_contains($identifier, '.')) {
+        if (!\str_contains($identifier, '.')) {
             // parent element
             return \sprintf(
                 '%s.%s',
                 $this->loader->getAlias(),
-                $this->loader->fieldAlias($identifier)
+                $this->loader->fieldAlias($identifier) ?? $identifier,
             );
         }
 
@@ -120,10 +120,11 @@ final class QueryBuilder
 
         $loader = $this->findLoader(\substr($identifier, 0, $split), $autoload);
         if ($loader !== null) {
+            $identifier = \substr($identifier, $split + 1);
             return \sprintf(
                 '%s.%s',
                 $loader->getAlias(),
-                $loader->fieldAlias(\substr($identifier, $split + 1))
+                $loader->fieldAlias($identifier) ?? $identifier,
             );
         }
 

--- a/src/Select/Repository.php
+++ b/src/Select/Repository.php
@@ -11,6 +11,7 @@ use Cycle\ORM\Select;
  * Repository provides ability to load entities and construct queries.
  *
  * @template TEntity of object
+ *
  * @implements RepositoryInterface<TEntity>
  */
 class Repository implements RepositoryInterface

--- a/src/Select/RootLoader.php
+++ b/src/Select/RootLoader.php
@@ -118,7 +118,7 @@ final class RootLoader extends AbstractLoader
             $loader->loadData($node->getNode($relation), $includeRole);
         }
 
-        $this->loadIerarchy($node, $includeRole);
+        $this->loadHierarchy($node, $includeRole);
     }
 
     public function isLoaded(): bool

--- a/src/Select/RootLoader.php
+++ b/src/Select/RootLoader.php
@@ -69,7 +69,7 @@ final class RootLoader extends AbstractLoader
     }
 
     /**
-     * Get primary key column identifier (aliased).
+     * Primary column name list with table name like `table.column`.
      *
      * @return string|string[]
      */
@@ -85,6 +85,16 @@ final class RootLoader extends AbstractLoader
         }
 
         return $this->getAlias() . '.' . $this->fieldAlias($pk);
+    }
+
+    /**
+     * Get list of primary fields.
+     *
+     * @return list<non-empty-string>
+     */
+    public function getPrimaryFields(): array
+    {
+        return (array)$this->define(SchemaInterface::PRIMARY_KEY);
     }
 
     /**

--- a/src/Select/RootLoader.php
+++ b/src/Select/RootLoader.php
@@ -47,7 +47,7 @@ final class RootLoader extends AbstractLoader
         $this->query = $this->source->getDatabase()->select()->from(
             sprintf('%s AS %s', $this->source->getTable(), $this->getAlias())
         );
-        $this->columns = $this->define(SchemaInterface::COLUMNS);
+        $this->columns = $this->normalizeColumns($this->define(SchemaInterface::COLUMNS));
 
         foreach ($this->getEagerLoaders() as $relation) {
             $this->loadRelation($relation, [], false, true);

--- a/src/Select/Traits/ColumnsTrait.php
+++ b/src/Select/Traits/ColumnsTrait.php
@@ -76,6 +76,7 @@ trait ColumnsTrait
      * @param non-empty-string[] $columns
      *
      * @return array<non-empty-string, non-empty-string>
+     *
      * @psalm-pure
      */
     #[Pure]

--- a/src/Select/Traits/ColumnsTrait.php
+++ b/src/Select/Traits/ColumnsTrait.php
@@ -26,7 +26,7 @@ trait ColumnsTrait
      */
     public function fieldAlias(string $field): ?string
     {
-        return $this->columns[$field] ?? (\in_array($field, $this->columns, true) ? $field : null);
+        return $this->columns[$field] ?? null;
     }
 
     /**

--- a/src/Select/Traits/ColumnsTrait.php
+++ b/src/Select/Traits/ColumnsTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\ORM\Select\Traits;
 
 use Cycle\Database\Query\SelectQuery;
+use JetBrains\PhpStorm\Pure;
 
 /**
  * Provides ability to add aliased columns into SelectQuery.
@@ -16,16 +17,16 @@ trait ColumnsTrait
     /**
      * List of columns associated with the loader.
      *
-     * @var string[]
+     * @var array<non-empty-string, non-empty-string>
      */
-    protected array $columns;
+    protected array $columns = [];
 
     /**
      * Return column name associated with given field.
      */
-    public function fieldAlias(string $field): string
+    public function fieldAlias(string $field): ?string
     {
-        return $this->columns[$field] ?? $field;
+        return $this->columns[$field] ?? (\in_array($field, $this->columns, true) ? $field : null);
     }
 
     /**
@@ -46,19 +47,13 @@ trait ColumnsTrait
         $columns = $overwrite ? [] : $query->getColumns();
 
         foreach ($this->columns as $internal => $external) {
-            $name = $external;
-            if (!\is_numeric($internal)) {
-                $name = $internal;
-            }
-
-            $column = $name;
-
+            $name = $internal;
             if ($minify) {
                 //Let's use column number instead of full name
-                $column = 'c' . \count($columns);
+                $name = 'c' . \count($columns);
             }
 
-            $columns[] = "{$alias}.{$external} AS {$prefix}{$column}";
+            $columns[] = "{$alias}.{$external} AS {$prefix}{$name}";
         }
 
         return $query->columns($columns);
@@ -69,20 +64,28 @@ trait ColumnsTrait
      */
     protected function columnNames(): array
     {
-        $result = [];
-        foreach ($this->columns as $internal => $external) {
-            if (!\is_numeric($internal)) {
-                $result[] = $internal;
-            } else {
-                $result[] = $external;
-            }
-        }
-
-        return $result;
+        return \array_keys($this->columns);
     }
 
     /**
      * Table alias of the loader.
      */
     abstract protected function getAlias(): string;
+
+    /**
+     * @param non-empty-string[] $columns
+     *
+     * @return array<non-empty-string, non-empty-string>
+     * @psalm-pure
+     */
+    #[Pure]
+    private function normalizeColumns(array $columns): array
+    {
+        $result = [];
+        foreach ($columns as $alias => $column) {
+            $result[\is_int($alias) ? $column : $alias] = $column;
+        }
+
+        return $result;
+    }
 }

--- a/src/Transaction/Pool.php
+++ b/src/Transaction/Pool.php
@@ -15,6 +15,7 @@ use Traversable;
 
 /**
  * @internal
+ *
  * @psalm-suppress TypeDoesNotContainType
  * @psalm-suppress RedundantCondition
  */
@@ -31,6 +32,7 @@ final class Pool implements \Countable
 
     /**
      * @var Tuple[]
+     *
      * @psalm-var list<Tuple>
      */
     private array $unprocessed;

--- a/src/Transaction/StateInterface.php
+++ b/src/Transaction/StateInterface.php
@@ -13,6 +13,7 @@ interface StateInterface
      * Check if transaction has been run successful.
      *
      * @psalm-assert-if-true null $this->getLastError()
+     *
      * @psalm-assert-if-false Throwable $this->getLastError()
      */
     public function isSuccess(): bool;

--- a/tests/ORM/Fixtures/Annotated.php
+++ b/tests/ORM/Fixtures/Annotated.php
@@ -7,6 +7,7 @@ namespace Cycle\ORM\Tests\Fixtures;
 
 /**
  * @entity (role="annotated")
+ *
  * @table (database="default", table="annotated", indexes={@index (columns={"email"}, unique=true)})
  */
 class Annotated

--- a/tests/ORM/Fixtures/TestLogger.php
+++ b/tests/ORM/Fixtures/TestLogger.php
@@ -102,6 +102,6 @@ class TestLogger implements LoggerInterface
 
 
 
-         ;
+        ;
     }
 }

--- a/tests/ORM/Functional/Driver/Common/Inheritance/Fixture/RbacItemAbstract.php
+++ b/tests/ORM/Functional/Driver/Common/Inheritance/Fixture/RbacItemAbstract.php
@@ -19,12 +19,14 @@ class RbacItemAbstract
 
     /**
      * @var DoctrineCollection|RbacPermission[]|RbacRole[]
+     *
      * @phpstan-var DoctrineCollection<string,RbacRole|RbacPermission>
      */
     public $parents;
 
     /**
      * @var DoctrineCollection|RbacPermission[]|RbacRole[]
+     *
      * @phpstan-var DoctrineCollection<string,RbacRole|RbacPermission>
      */
     public $children;

--- a/tests/ORM/Functional/Driver/Common/Inheritance/JTI/CompositePKTest.php
+++ b/tests/ORM/Functional/Driver/Common/Inheritance/JTI/CompositePKTest.php
@@ -235,7 +235,7 @@ abstract class CompositePKTest extends SimpleCasesTest
         $this->assertNumWrites(0);
 
         /** @var Programator $programator */
-        $programator = (new Select($this->orm->withHeap(new Heap()), Programator::class))
+        $programator = (new Select($this->orm->with(heap: new Heap()), Programator::class))
             ->wherePK(['second_id' => 11, 'subrole_id' => 10])
             ->fetchOne();
         $this->assertSame(10, $programator->id);

--- a/tests/ORM/Functional/Driver/Common/Inheritance/JTI/SimpleCasesTest.php
+++ b/tests/ORM/Functional/Driver/Common/Inheritance/JTI/SimpleCasesTest.php
@@ -264,6 +264,15 @@ abstract class SimpleCasesTest extends JtiBaseTest
         $this->assertEquals(static::PROGRAMATOR_4_LOADED, $selector->fetchData()[0]);
     }
 
+    // Order by
+
+    public function testSelectProgramatorsWithSortingByParentField(): void
+    {
+        $selector = (new Select($this->orm, static::PROGRAMATOR_ROLE))->orderBy('age', 'ASC');
+
+        $this->assertEquals(\array_reverse(static::PROGRAMATOR_ALL_LOADED), $selector->fetchData());
+    }
+
     // Persist
 
     public function testProgramatorNoChanges(): void

--- a/tests/ORM/Functional/Driver/Common/Inheritance/JTI/SimpleCasesTest.php
+++ b/tests/ORM/Functional/Driver/Common/Inheritance/JTI/SimpleCasesTest.php
@@ -251,6 +251,18 @@ abstract class SimpleCasesTest extends JtiBaseTest
         $this->assertEquals(static::PROGRAMATOR_4_LOADED, $selector->fetchData()[0]);
     }
 
+    public function testSelectProgramatorUsingParentsFields(): void
+    {
+        $selector = (new Select($this->orm, static::PROGRAMATOR_ROLE))
+            ->where([
+                '@AND' => [
+                    ['name' => 'Valeriy'],
+                    ['level' => ['>=' => 10]],
+                ],
+            ]);
+
+        $this->assertEquals(static::PROGRAMATOR_4_LOADED, $selector->fetchData()[0]);
+    }
 
     // Persist
 

--- a/tests/ORM/Functional/Driver/Common/Inheritance/JTI/SimpleCasesTest.php
+++ b/tests/ORM/Functional/Driver/Common/Inheritance/JTI/SimpleCasesTest.php
@@ -233,6 +233,25 @@ abstract class SimpleCasesTest extends JtiBaseTest
         $this->assertEquals(static::MANAGER_1_LOADED, $selector->fetchData()[0]);
     }
 
+    // Select using Where condition
+
+    public function testSelectProgramatorUsingParentField(): void
+    {
+        $selector = (new Select($this->orm, static::PROGRAMATOR_ROLE))
+            ->where('level', '>=', 10);
+
+        $this->assertEquals(static::PROGRAMATOR_4_LOADED, $selector->fetchData()[0]);
+    }
+
+    public function testSelectProgramatorUsingParentParentField(): void
+    {
+        $selector = (new Select($this->orm, static::PROGRAMATOR_ROLE))
+            ->where('name', '=', 'Valeriy');
+
+        $this->assertEquals(static::PROGRAMATOR_4_LOADED, $selector->fetchData()[0]);
+    }
+
+
     // Persist
 
     public function testProgramatorNoChanges(): void

--- a/tests/ORM/Functional/Driver/Common/Integration/Case2/Entity/MarkCriterionResult.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case2/Entity/MarkCriterionResult.php
@@ -12,7 +12,7 @@ class MarkCriterionResult
     public ?string $id = null;
     public int $resultObjective = 0;
 
-    public Student $student;
+    public ?Student $student;
     public ?string $student_id = null;
 
     /** @var Collection<array-key, MarkSubcriterionResult> */

--- a/tests/ORM/Functional/Driver/Common/Relation/Embedded/EmbeddedCompositeKeyTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/Embedded/EmbeddedCompositeKeyTest.php
@@ -121,7 +121,7 @@ abstract class EmbeddedCompositeKeyTest extends BaseTest
         $this->save($u);
         $this->assertNumWrites(1);
 
-        $u2 = ((new Select($this->orm->withHeap(new Heap()), CompositePK::class)))
+        $u2 = (new Select($this->orm->withHeap(new Heap()), CompositePK::class))
             ->load(self::CHILD_CONTAINER)
             ->wherePK([$u->key1, $u->key2])
             ->fetchOne();

--- a/tests/ORM/Functional/Driver/Common/Relation/ManyToMany/ManyToManyNonPivotedCollectionTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/ManyToMany/ManyToManyNonPivotedCollectionTest.php
@@ -362,12 +362,12 @@ abstract class ManyToManyNonPivotedCollectionTest extends BaseTest
     private function createOrm(): ORMInterface
     {
         return new ORM(
-            (new Factory(
+            new Factory(
                 $this->dbal,
                 RelationConfig::getDefault(),
                 null,
                 new \Cycle\ORM\Collection\ArrayCollectionFactory()
-            )),
+            ),
             new Schema([])
         );
     }

--- a/tests/ORM/Functional/Driver/Common/Schema/CompositePKTest.php
+++ b/tests/ORM/Functional/Driver/Common/Schema/CompositePKTest.php
@@ -166,8 +166,7 @@ abstract class CompositePKTest extends BaseTest
 
         $this->save($u1);
 
-        // one entity with assoc PK. Keys - fields in db
-        $data1 = (new Select($this->orm, CompositePK::class))->wherePK(['field2' => 2, 'field1' => 1])->fetchOne();
+        $data1 = (new Select($this->orm, CompositePK::class))->wherePK(['key2' => 2, 'key1' => 1])->fetchOne();
 
         $this->assertSame($u1->key1, $data1->key1);
         $this->assertSame($u1->key2, $data1->key2);
@@ -230,8 +229,8 @@ abstract class CompositePKTest extends BaseTest
             'Incorrect count' => [
                 ['key1' => 1, 'key2' => 2, 'key3' => 3], 'Primary key should contain 2 values.',
             ],
-            'Don\'t exist' => [
-                ['foo' => 2, 'bar' => 1], 'Primary key simple_entity.foo not found.',
+            'Key not found' => [
+                ['foo' => 2, 'bar' => 1], 'Primary key `foo` not found.',
             ],
         ];
     }

--- a/tests/ORM/Functional/Driver/MySQL/Enum/EnumTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Enum/EnumTest.php
@@ -10,6 +10,7 @@ use Cycle\ORM\Tests\Functional\Driver\Common\Enum\EnumTest as CommonClass;
 /**
  * @group driver
  * @group driver-mysql
+ *
  * @requires PHP >= 8.1
  */
 class EnumTest extends CommonClass

--- a/tests/ORM/Functional/Driver/MySQL/Typecast/TypecastEnumTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Typecast/TypecastEnumTest.php
@@ -10,6 +10,7 @@ use Cycle\ORM\Tests\Functional\Driver\Common\Typecast\TypecastEnumTest as Common
 /**
  * @group driver
  * @group driver-mysql
+ *
  * @requires PHP >= 8.1
  */
 class TypecastEnumTest extends CommonClass

--- a/tests/ORM/Functional/Driver/Postgres/Enum/EnumTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Enum/EnumTest.php
@@ -10,6 +10,7 @@ use Cycle\ORM\Tests\Functional\Driver\Common\Enum\EnumTest as CommonClass;
 /**
  * @group driver
  * @group driver-postgres
+ *
  * @requires PHP >= 8.1
  */
 class EnumTest extends CommonClass

--- a/tests/ORM/Functional/Driver/Postgres/Typecast/TypecastEnumTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Typecast/TypecastEnumTest.php
@@ -10,6 +10,7 @@ use Cycle\ORM\Tests\Functional\Driver\Common\Typecast\TypecastEnumTest as Common
 /**
  * @group driver
  * @group driver-postgres
+ *
  * @requires PHP >= 8.1
  */
 class TypecastEnumTest extends CommonClass

--- a/tests/ORM/Functional/Driver/SQLServer/Enum/EnumTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Enum/EnumTest.php
@@ -10,6 +10,7 @@ use Cycle\ORM\Tests\Functional\Driver\Common\Enum\EnumTest as CommonClass;
 /**
  * @group driver
  * @group driver-sqlserver
+ *
  * @requires PHP >= 8.1
  */
 class EnumTest extends CommonClass

--- a/tests/ORM/Functional/Driver/SQLServer/Typecast/TypecastEnumTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Typecast/TypecastEnumTest.php
@@ -10,6 +10,7 @@ use Cycle\ORM\Tests\Functional\Driver\Common\Typecast\TypecastEnumTest as Common
 /**
  * @group driver
  * @group driver-sqlserver
+ *
  * @requires PHP >= 8.1
  */
 class TypecastEnumTest extends CommonClass

--- a/tests/ORM/Functional/Driver/SQLite/Enum/EnumTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Enum/EnumTest.php
@@ -10,6 +10,7 @@ use Cycle\ORM\Tests\Functional\Driver\Common\Enum\EnumTest as CommonClass;
 /**
  * @group driver
  * @group driver-sqlite
+ *
  * @requires PHP >= 8.1
  */
 class EnumTest extends CommonClass

--- a/tests/ORM/Functional/Driver/SQLite/Typecast/TypecastEnumTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Typecast/TypecastEnumTest.php
@@ -10,6 +10,7 @@ use Cycle\ORM\Tests\Functional\Driver\Common\Typecast\TypecastEnumTest as Common
 /**
  * @group driver
  * @group driver-sqlite
+ *
  * @requires PHP >= 8.1
  */
 class TypecastEnumTest extends CommonClass

--- a/tests/ORM/Unit/Parser/TypecastTest.php
+++ b/tests/ORM/Unit/Parser/TypecastTest.php
@@ -97,6 +97,7 @@ class TypecastTest extends TestCase
 
     /**
      * @requires PHP >= 8.1
+     *
      * @dataProvider enumCastDataProvider
      */
     public function testEnumCast(array $rules, array $in, array $out): void


### PR DESCRIPTION
Closes #404 

Also:
- make `Select::wherePK()` more strict (you should use entity field name instead of columns)
- fix method naming `AbstractLoader::loadIerarchy()` (deprecated and renamed to `::loadHierarchy()`)