### PR TITLE
Fix: remove extra joins from JTI and eager relations when ManyToMany is resolved

### DIFF
--- a/src/Relation/ManyToMany.php
+++ b/src/Relation/ManyToMany.php
@@ -248,12 +248,14 @@ class ManyToMany extends Relation\AbstractRelation
             return $result;
         }
 
+        $source = $this->sourceProvider->getSource($this->target);
         // getting scoped query
         $query = (new RootLoader(
             $this->ormSchema,
             $this->sourceProvider,
             $this->factory,
-            $this->target
+            $this->target,
+            loadRelations: false,
         ))->buildQuery();
 
         // responsible for all the scoping
@@ -261,14 +263,14 @@ class ManyToMany extends Relation\AbstractRelation
             $this->ormSchema,
             $this->sourceProvider,
             $this->factory,
-            $this->sourceProvider->getSource($this->target)->getTable(),
+            $source->getTable(),
             $this->target,
             $this->schema
         );
 
         /** @var ManyToManyLoader $loader */
         $loader = $loader->withContext($loader, [
-            'scope' => $this->sourceProvider->getSource($this->target)->getScope(),
+            'scope' => $source->getScope(),
             'as' => $this->target,
             'method' => JoinableLoader::POSTLOAD,
         ]);

--- a/src/Select/JoinableLoader.php
+++ b/src/Select/JoinableLoader.php
@@ -109,7 +109,7 @@ abstract class JoinableLoader extends AbstractLoader implements JoinableInterfac
         //Calculate table alias
         $loader->options['as'] = $loader->calculateAlias($parent);
 
-        if (array_key_exists('scope', $options)) {
+        if (\array_key_exists('scope', $options)) {
             if ($loader->options['scope'] instanceof ScopeInterface) {
                 $loader->setScope($loader->options['scope']);
             } elseif (\is_string($loader->options['scope'])) {

--- a/src/Select/Loader/ParentLoader.php
+++ b/src/Select/Loader/ParentLoader.php
@@ -8,6 +8,8 @@ use Cycle\Database\Query\SelectQuery;
 use Cycle\ORM\FactoryInterface;
 use Cycle\ORM\Parser\AbstractNode;
 use Cycle\ORM\Parser\ParentMergeNode;
+use Cycle\ORM\Select\AbstractLoader;
+use Cycle\ORM\Select\RootLoader;
 use Cycle\ORM\Service\SourceProviderInterface;
 use Cycle\ORM\Relation;
 use Cycle\ORM\SchemaInterface;
@@ -71,6 +73,17 @@ class ParentLoader extends JoinableLoader
     protected function getJoinMethod(): string
     {
         return 'INNER';
+    }
+
+    protected function calculateAlias(AbstractLoader $parent): string
+    {
+        $alias = parent::calculateAlias($parent);
+
+        if ($parent instanceof RootLoader) {
+            return 'parent_' . $alias;
+        }
+
+        return $alias;
     }
 
     protected function initNode(): AbstractNode

--- a/src/Select/Loader/ParentLoader.php
+++ b/src/Select/Loader/ParentLoader.php
@@ -8,8 +8,6 @@ use Cycle\Database\Query\SelectQuery;
 use Cycle\ORM\FactoryInterface;
 use Cycle\ORM\Parser\AbstractNode;
 use Cycle\ORM\Parser\ParentMergeNode;
-use Cycle\ORM\Select\AbstractLoader;
-use Cycle\ORM\Select\RootLoader;
 use Cycle\ORM\Service\SourceProviderInterface;
 use Cycle\ORM\Relation;
 use Cycle\ORM\SchemaInterface;
@@ -73,17 +71,6 @@ class ParentLoader extends JoinableLoader
     protected function getJoinMethod(): string
     {
         return 'INNER';
-    }
-
-    protected function calculateAlias(AbstractLoader $parent): string
-    {
-        $alias = parent::calculateAlias($parent);
-
-        if ($parent instanceof RootLoader) {
-            return 'parent_' . $alias;
-        }
-
-        return $alias;
     }
 
     protected function initNode(): AbstractNode

--- a/src/Select/RootLoader.php
+++ b/src/Select/RootLoader.php
@@ -37,11 +37,15 @@ final class RootLoader extends AbstractLoader
 
     private SelectQuery $query;
 
+    /**
+     * @param bool $loadRelations Define loading eager relations and JTI hierarchy.
+     */
     public function __construct(
         SchemaInterface $ormSchema,
         SourceProviderInterface $sourceProvider,
         FactoryInterface $factory,
-        string $target
+        string $target,
+        bool $loadRelations = true,
     ) {
         parent::__construct($ormSchema, $sourceProvider, $factory, $target);
         $this->query = $this->source->getDatabase()->select()->from(
@@ -49,8 +53,10 @@ final class RootLoader extends AbstractLoader
         );
         $this->columns = $this->normalizeColumns($this->define(SchemaInterface::COLUMNS));
 
-        foreach ($this->getEagerLoaders() as $relation) {
-            $this->loadRelation($relation, [], false, true);
+        if ($loadRelations) {
+            foreach ($this->getEagerLoaders() as $relation) {
+                $this->loadRelation($relation, [], false, true);
+            }
         }
     }
 

--- a/tests/ORM/Functional/Driver/Common/Integration/Case5/CaseTest.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case5/CaseTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case5;
+
+use Cycle\ORM\Select;
+use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case5\Entity\Buyer;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\IntegrationTestTrait;
+use Cycle\ORM\Tests\Traits\TableTrait;
+
+abstract class CaseTest extends BaseTest
+{
+    use IntegrationTestTrait;
+    use TableTrait;
+
+    public function setUp(): void
+    {
+        // Init DB
+        parent::setUp();
+
+        // Make tables
+        $this->makeTable('users', [
+            'id' => 'primary',
+            'name' => 'string',
+        ]);
+        $this->makeTable('buyers', [
+            'id' => 'primary',
+            'address' => 'string',
+        ]);
+        $this->makeTable(
+            table: 'buyer_partners',
+            columns: [
+                'buyer_id' => 'int',
+                'partner_id' => 'int',
+            ],
+            pk: ['buyer_id', 'partner_id'],
+        );
+
+        $this->loadSchema(__DIR__ . '/schema.php');
+
+        $this->getDatabase()->table('users')->insertMultiple(
+            ['id', 'name'],
+            [[1, 'John'], [2, 'Sam'], [3, 'Paul']],
+        );
+        $this->getDatabase()->table('buyers')->insertMultiple(
+            ['id', 'address'],
+            [[1, 'foo'], [2, 'bar'], [3, 'baz']],
+        );
+        $this->getDatabase()->table('buyer_partners')->insertMultiple(
+            ['buyer_id', 'partner_id'],
+            [[1, 2], [1, 3]],
+        );
+    }
+
+    public function testSelect(): void
+    {
+        /** @var Buyer $buyer */
+        $buyer = (new Select($this->orm, Buyer::class))
+            ->wherePK(1)
+            ->fetchOne();
+
+        // It's important. $buyer->partners - will trigger relation load and we test it
+        $this->assertEquals([
+            new Buyer(id: 2, name: 'Sam', address: 'bar'),
+            new Buyer(id: 3, name: 'Paul', address: 'baz'),
+        ], $buyer->partners);
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Case5/CaseTest.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case5/CaseTest.php
@@ -29,6 +29,10 @@ abstract class CaseTest extends BaseTest
             'id' => 'primary',
             'address' => 'string',
         ]);
+        $this->makeTable('badge_table', [
+            'id' => 'primary',
+            'label' => 'string',
+        ]);
         $this->makeTable(
             table: 'case_5_buyer_partners',
             columns: [
@@ -47,6 +51,10 @@ abstract class CaseTest extends BaseTest
         $this->getDatabase()->table('case_5_buyers')->insertMultiple(
             ['address'],
             [['foo'], ['bar'], ['baz']],
+        );
+        $this->getDatabase()->table('badge_table')->insertMultiple(
+            ['label'],
+            [['lab'], ['bal'], ['abl']],
         );
         $this->getDatabase()->table('case_5_buyer_partners')->insertMultiple(
             ['buyer_id', 'partner_id'],
@@ -69,5 +77,6 @@ abstract class CaseTest extends BaseTest
             return $element->id === 3;
         }));
         $this->assertCount(2, $buyer->partners);
+        $this->assertSame('lab', $buyer->badge->label);
     }
 }

--- a/tests/ORM/Functional/Driver/Common/Integration/Case5/CaseTest.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case5/CaseTest.php
@@ -21,16 +21,16 @@ abstract class CaseTest extends BaseTest
         parent::setUp();
 
         // Make tables
-        $this->makeTable('users', [
+        $this->makeTable('case_5_users', [
             'id' => 'primary',
             'name' => 'string',
         ]);
-        $this->makeTable('buyers', [
+        $this->makeTable('case_5_buyers', [
             'id' => 'primary',
             'address' => 'string',
         ]);
         $this->makeTable(
-            table: 'buyer_partners',
+            table: 'case_5_buyer_partners',
             columns: [
                 'buyer_id' => 'int',
                 'partner_id' => 'int',
@@ -40,15 +40,15 @@ abstract class CaseTest extends BaseTest
 
         $this->loadSchema(__DIR__ . '/schema.php');
 
-        $this->getDatabase()->table('users')->insertMultiple(
-            ['id', 'name'],
-            [[1, 'John'], [2, 'Sam'], [3, 'Paul']],
+        $this->getDatabase()->table('case_5_users')->insertMultiple(
+            ['name'],
+            [['John'], ['Sam'], ['Paul']],
         );
-        $this->getDatabase()->table('buyers')->insertMultiple(
-            ['id', 'address'],
-            [[1, 'foo'], [2, 'bar'], [3, 'baz']],
+        $this->getDatabase()->table('case_5_buyers')->insertMultiple(
+            ['address'],
+            [['foo'], ['bar'], ['baz']],
         );
-        $this->getDatabase()->table('buyer_partners')->insertMultiple(
+        $this->getDatabase()->table('case_5_buyer_partners')->insertMultiple(
             ['buyer_id', 'partner_id'],
             [[1, 2], [1, 3]],
         );
@@ -62,9 +62,12 @@ abstract class CaseTest extends BaseTest
             ->fetchOne();
 
         // It's important. $buyer->partners - will trigger relation load and we test it
-        $this->assertEquals([
-            new Buyer(id: 2, name: 'Sam', address: 'bar'),
-            new Buyer(id: 3, name: 'Paul', address: 'baz'),
-        ], $buyer->partners);
+        $this->assertTrue($buyer->partners->exists(function (int $key, Buyer $element): bool {
+            return $element->id === 2;
+        }));
+        $this->assertTrue($buyer->partners->exists(function (int $key, Buyer $element): bool {
+            return $element->id === 3;
+        }));
+        $this->assertCount(2, $buyer->partners);
     }
 }

--- a/tests/ORM/Functional/Driver/Common/Integration/Case5/Entity/Badge.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case5/Entity/Badge.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case5\Entity;
+
+class Badge
+{
+    public function __construct(
+        public int $id,
+        public string $label,
+    ) {
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Case5/Entity/Buyer.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case5/Entity/Buyer.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Collections\Collection;
 class Buyer extends User
 {
     public Collection $partners;
+    public Badge $badge;
 
     public function __construct(
         int $id,

--- a/tests/ORM/Functional/Driver/Common/Integration/Case5/Entity/Buyer.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case5/Entity/Buyer.php
@@ -4,15 +4,20 @@ declare(strict_types=1);
 
 namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case5\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
 class Buyer extends User
 {
+    public Collection $partners;
+
     public function __construct(
         int $id,
         string $name,
         public string $address,
-        public array $partners = []
     ) {
         $this->id = $id;
         $this->name = $name;
+        $this->partners = new ArrayCollection();
     }
 }

--- a/tests/ORM/Functional/Driver/Common/Integration/Case5/Entity/Buyer.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case5/Entity/Buyer.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case5\Entity;
+
+class Buyer extends User
+{
+    public function __construct(
+        int $id,
+        string $name,
+        public string $address,
+        public array $partners = []
+    ) {
+        $this->id = $id;
+        $this->name = $name;
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Case5/Entity/BuyerPartner.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case5/Entity/BuyerPartner.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case5\Entity;
+
+class BuyerPartner
+{
+    public int $buyer_id;
+    public int $partner_id;
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Case5/Entity/User.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case5/Entity/User.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case5\Entity;
+
+abstract class User
+{
+    public int $id;
+    public string $name;
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Case5/schema.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case5/schema.php
@@ -11,7 +11,7 @@ use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case5\Entity\User;
 return [
     'user' => [
         Schema::ENTITY => User::class,
-        Schema::TABLE => 'users',
+        Schema::TABLE => 'case_5_users',
         Schema::PRIMARY_KEY => ['id'],
         Schema::COLUMNS => [
             'id' => 'id',
@@ -23,7 +23,7 @@ return [
     ],
     'buyer' => [
         Schema::ENTITY => Buyer::class,
-        Schema::TABLE => 'buyers',
+        Schema::TABLE => 'case_5_buyers',
         Schema::PRIMARY_KEY => ['id'],
         Schema::PARENT => 'user',
         Schema::COLUMNS => [
@@ -50,7 +50,7 @@ return [
     ],
     'buyer_partner' => [
         Schema::ENTITY => BuyerPartner::class,
-        Schema::TABLE => 'buyer_partners',
+        Schema::TABLE => 'case_5_buyer_partners',
         Schema::PRIMARY_KEY => ['buyer_id', 'partner_id'],
         Schema::COLUMNS => [
             'buyer_id' => 'buyer_id',

--- a/tests/ORM/Functional/Driver/Common/Integration/Case5/schema.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case5/schema.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Cycle\ORM\Relation;
+use Cycle\ORM\SchemaInterface as Schema;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case5\Entity\Buyer;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case5\Entity\BuyerPartner;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case5\Entity\User;
+
+return [
+    'user' => [
+        Schema::ENTITY => User::class,
+        Schema::TABLE => 'users',
+        Schema::PRIMARY_KEY => ['id'],
+        Schema::COLUMNS => [
+            'id' => 'id',
+            'name' => 'name',
+        ],
+        Schema::TYPECAST => [
+            'id' => 'int',
+        ],
+    ],
+    'buyer' => [
+        Schema::ENTITY => Buyer::class,
+        Schema::TABLE => 'buyers',
+        Schema::PRIMARY_KEY => ['id'],
+        Schema::PARENT => 'user',
+        Schema::COLUMNS => [
+            'id' => 'id',
+            'address' => 'address',
+        ],
+        Schema::TYPECAST => [
+            'id' => 'int',
+        ],
+        Schema::RELATIONS => [
+            'partners' => [
+                Relation::TYPE => Relation::MANY_TO_MANY,
+                Relation::TARGET => 'buyer',
+                Relation::LOAD => Relation::LOAD_PROMISE,
+                Relation::SCHEMA => [
+                    Relation::THROUGH_ENTITY => 'buyer_partner',
+                    Relation::INNER_KEY => 'id',
+                    Relation::OUTER_KEY => 'id',
+                    Relation::THROUGH_INNER_KEY => 'buyer_id',
+                    Relation::THROUGH_OUTER_KEY => 'partner_id',
+                ],
+            ],
+        ],
+    ],
+    'buyer_partner' => [
+        Schema::ENTITY => BuyerPartner::class,
+        Schema::TABLE => 'buyer_partners',
+        Schema::PRIMARY_KEY => ['buyer_id', 'partner_id'],
+        Schema::COLUMNS => [
+            'buyer_id' => 'buyer_id',
+            'partner_id' => 'partner_id',
+        ],
+        Schema::TYPECAST => [
+            'buyer_id' => 'int',
+            'partner_id' => 'int',
+        ],
+    ],
+];

--- a/tests/ORM/Functional/Driver/Common/Integration/Case5/schema.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case5/schema.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Cycle\ORM\Relation;
 use Cycle\ORM\SchemaInterface as Schema;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case5\Entity\Badge;
 use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case5\Entity\Buyer;
 use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case5\Entity\BuyerPartner;
 use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case5\Entity\User;
@@ -46,6 +47,15 @@ return [
                     Relation::THROUGH_OUTER_KEY => 'partner_id',
                 ],
             ],
+            'badge' => [
+                Relation::TYPE => Relation::HAS_ONE,
+                Relation::TARGET => 'badge',
+                Relation::LOAD => Relation::LOAD_EAGER,
+                Relation::SCHEMA => [
+                    Relation::INNER_KEY => 'id',
+                    Relation::OUTER_KEY => 'id',
+                ],
+            ],
         ],
     ],
     'buyer_partner' => [
@@ -59,6 +69,18 @@ return [
         Schema::TYPECAST => [
             'buyer_id' => 'int',
             'partner_id' => 'int',
+        ],
+    ],
+    'badge' => [
+        Schema::ENTITY => Badge::class,
+        Schema::TABLE => 'badge_table',
+        Schema::PRIMARY_KEY => ['id'],
+        Schema::COLUMNS => [
+            'id' => 'id',
+            'label' => 'label',
+        ],
+        Schema::TYPECAST => [
+            'id' => 'int',
         ],
     ],
 ];

--- a/tests/ORM/Functional/Driver/MySQL/Integration/Case5/CaseTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Integration/Case5/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\MySQL\Integration\Case5;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case5\CaseTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/ORM/Functional/Driver/Postgres/Integration/Case5/CaseTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Integration/Case5/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Postgres\Integration\Case5;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case5\CaseTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/ORM/Functional/Driver/SQLServer/Integration/Case5/CaseTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Integration/Case5/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLServer\Integration\Case5;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case5\CaseTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/ORM/Functional/Driver/SQLite/Integration/Case5/CaseTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Integration/Case5/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLite\Integration\Case5;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case5\CaseTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+}


### PR DESCRIPTION
This test case demonstrates the duplication of an inner join with an alias user when loading a relation. 
Generated SQL:

```sql
SELECT "buyer_pivot"."buyer_id" AS "c0", "buyer_pivot"."partner_id" AS "c1", "buyer"."id" AS "c2", "buyer"."address" AS "c3", "user"."id" AS "c4", "user"."name" AS "c5"
FROM "buyers" AS "buyer" 
INNER JOIN "users" AS "user"
    ON "user"."id" = "buyer"."id" 
LEFT JOIN "buyer_partners" AS "buyer_pivot"
    ON "buyer_pivot"."partner_id" = "buyer"."id" 
INNER JOIN "users" AS "user"
    ON "user"."id" = "buyer"."id"  
WHERE "buyer_pivot"."buyer_id" IN (?) 
```