### PR TITLE
Support uninitialized collections

### DIFF
--- a/src/Mapper/Proxy/ProxyEntityFactory.php
+++ b/src/Mapper/Proxy/ProxyEntityFactory.php
@@ -101,7 +101,9 @@ class ProxyEntityFactory
         foreach ($relMap->getRelations() as $key => $relation) {
             if (!array_key_exists($key, $currentData)) {
                 $arrayData ??= $this->entityToArray($entity);
-                $currentData[$key] = $arrayData[$key];
+                if (\array_key_exists($key, $arrayData)) {
+                    $currentData[$key] = $arrayData[$key];
+                }
             }
         }
 

--- a/src/Relation/HasMany.php
+++ b/src/Relation/HasMany.php
@@ -64,10 +64,14 @@ class HasMany extends AbstractRelation
             $related = $this->resolve($related, true);
             $tuple->state->setRelation($this->getName(), $related);
         } elseif (!\is_iterable($related)) {
-            throw new BadRelationValueException(\sprintf(
-                'Value for Has Many relation must be of the iterable type, %s given.',
-                \gettype($related),
-            ));
+            if ($related === null) {
+                $related = $this->collect([]);
+            } else {
+                throw new BadRelationValueException(\sprintf(
+                    'Value for Has Many relation must be of the iterable type, %s given.',
+                    \get_debug_type($related),
+                ));
+            }
         }
         foreach ($this->calcDeleted($related, $original ?? []) as $item) {
             $this->deleteChild($pool, $tuple, $item);


### PR DESCRIPTION
## What was changed

Ignore uninitialized collections in HasMany and ManyToMany relations.
Unsetting of collection property means unlinking children.

Fix #339