### PR TITLE
Fix belongs to relation when parent is changed using parent id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+v2.3.4 (31.07.2023)
+--------------------
+- Fix fields uncasting in the ManyToMany relation by @roxblnfk, thanks @gam6itko (#427, #428)
+- Fix resolving of a not loaded parent in the relation RefersTo by @roxblnfk, thanks @msmakouz and snafets (#414)
+- Fix belongs to relation when parent is changed using parent id by @roxblnfk, thanks @roquie (#346, #432)
+
 v2.3.3 (21.07.2023)
 --------------------
 - Fix loading for Embedded entities when parent is null by @gam6itko and @roxblnfk (#422, #423)
@@ -11,7 +17,7 @@ v2.3.2 (20.06.2023)
 --------------------
 - Fix proxy-mapper hydration mechanism: public relations in a non-proxy-entity are hydrated like private ones.
   There is a special logic related to `ReferenceInterface` hydrating. By @roxblnfk (#417)
-- Add the method `forUpdate` in the `Select` phpdoc. By @msmakouz in (#413)
+- Add the method `forUpdate` in the `Select` phpdoc. By @msmakouz (#413)
 
 v2.3.1 (01.05.2023)
 --------------------

--- a/src/Heap/Node.php
+++ b/src/Heap/Node.php
@@ -129,15 +129,11 @@ final class Node
     {
         $changes = array_udiff_assoc($state->getTransactionData(), $this->data, [self::class, 'compare']);
 
-        $relations = $relMap->getRelations();
-        foreach ($state->getRelations() as $name => $relation) {
-            if ($relation instanceof ReferenceInterface
-                && isset($relations[$name])
-                && (isset($this->relations[$name]) xor isset($relation))
-            ) {
-                $changes[$name] = $relation->hasValue() ? $relation->getValue() : $relation;
+        foreach ($state->getRelations() as $name => $value) {
+            if ($value instanceof ReferenceInterface) {
+                $changes[$name] = $value->hasValue() ? $value->getValue() : $value;
             }
-            $this->setRelation($name, $relation);
+            $this->setRelation($name, $value);
         }
 
         // DELETE handled separately

--- a/src/Mapper/Proxy/Hydrator/ClosureHydrator.php
+++ b/src/Mapper/Proxy/Hydrator/ClosureHydrator.php
@@ -34,7 +34,10 @@ class ClosureHydrator
 
         foreach ($data as $property => $value) {
             try {
-                // Ignore deprecations
+                if (isset($relMap->getRelations()[$property])) {
+                    unset($object->{$property});
+                }
+                // Use @ to try to ignore deprecations
                 @$object->{$property} = $value;
             } catch (\Throwable $e) {
                 if ($e::class === \TypeError::class) {
@@ -66,7 +69,7 @@ class ClosureHydrator
                     }
 
                     try {
-                        // Ignore deprecations
+                        // Use @ to try to ignore deprecations
                         @$object->{$property} = $data[$property];
                         unset($data[$property]);
                     } catch (\Throwable $e) {

--- a/src/Mapper/Proxy/ProxyEntityFactory.php
+++ b/src/Mapper/Proxy/ProxyEntityFactory.php
@@ -101,7 +101,10 @@ class ProxyEntityFactory
         foreach ($relMap->getRelations() as $key => $relation) {
             if (!array_key_exists($key, $currentData)) {
                 $arrayData ??= $this->entityToArray($entity);
-                $currentData[$key] = $arrayData[$key];
+                if (!array_key_exists($key, $arrayData)) {
+                    continue;
+                }
+                $currentData[$key] = $arrayData[$key] ?? null;
             }
         }
 

--- a/tests/ORM/Functional/Driver/Common/Integration/Case346/CaseTest.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case346/CaseTest.php
@@ -36,6 +36,10 @@ abstract class CaseTest extends BaseTest
         $post->user_id = 2;
 
         $this->save($post);
+
+        $this->assertSame(2, $post->user_id);
+        $this->assertSame(2, $post->user->id);
+        $this->orm->getHeap()->clean();
     }
 
     private function makeTables(): void

--- a/tests/ORM/Functional/Driver/Common/Integration/Case346/CaseTest.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case346/CaseTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case346;
+
+use Cycle\ORM\Select;
+use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\IntegrationTestTrait;
+use Cycle\ORM\Tests\Traits\TableTrait;
+
+abstract class CaseTest extends BaseTest
+{
+    use IntegrationTestTrait;
+    use TableTrait;
+
+    public function setUp(): void
+    {
+        // Init DB
+        parent::setUp();
+        $this->makeTables();
+        $this->fillData();
+
+        $this->loadSchema(__DIR__ . '/schema.php');
+    }
+
+    public function testSelect(): void
+    {
+        /** @var Entity\Post $post */
+        $post = (new Select($this->orm, Entity\Post::class))
+            ->wherePK(1)
+            ->fetchOne();
+
+        $this->assertSame(1, $post->user->id);
+
+        $post->user_id = 2;
+
+        $this->save($post);
+    }
+
+    private function makeTables(): void
+    {
+        // Make tables
+        $this->makeTable(Entity\User::ROLE, [
+            'id' => 'primary', // autoincrement
+            'login' => 'string',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ]);
+
+        $this->makeTable('post', [
+            'id' => 'primary',
+            'user_id' => 'int',
+            'slug' => 'string',
+            'title' => 'string',
+            'public' => 'bool',
+            'content' => 'string',
+            'published_at' => 'datetime,nullable',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+            'deleted_at' => 'datetime,nullable',
+        ]);
+        $this->makeFK('post', 'user_id', 'user', 'id', 'NO ACTION', 'NO ACTION');
+    }
+
+    private function fillData(): void
+    {
+        $this->getDatabase()->table('user')->insertMultiple(
+            ['login'],
+            [
+                ['user-1'],
+                ['user-2'],
+                ['user-3'],
+                ['user-4'],
+            ],
+        );
+        $this->getDatabase()->table('post')->insertMultiple(
+            ['user_id', 'slug', 'title', 'public', 'content'],
+            [
+                [1, 'slug-string-1', 'Title 1', true, 'Foo-bar-baz content 1'],
+                [2, 'slug-string-2', 'Title 2', true, 'Foo-bar-baz content 2'],
+                [2, 'slug-string-3', 'Title 3', true, 'Foo-bar-baz content 3'],
+                [3, 'slug-string-4', 'Title 4', true, 'Foo-bar-baz content 4'],
+                [3, 'slug-string-5', 'Title 5', true, 'Foo-bar-baz content 5'],
+                [3, 'slug-string-6', 'Title 6', true, 'Foo-bar-baz content 6'],
+            ],
+        );
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Case346/Entity/Post.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case346/Entity/Post.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case346\Entity;
+
+use DateTimeImmutable;
+
+class Post
+{
+    public ?int $id = null;
+    public string $slug;
+    public string $title = '';
+    public bool $public = false;
+    public string $content = '';
+    public DateTimeImmutable $created_at;
+    public DateTimeImmutable $updated_at;
+    public ?DateTimeImmutable $published_at = null;
+    public ?DateTimeImmutable $deleted_at = null;
+    public User $user;
+    public ?int $user_id = null;
+
+    public function __construct(string $title = '', string $content = '')
+    {
+        $this->title = $title;
+        $this->content = $content;
+        $this->created_at = new DateTimeImmutable();
+        $this->updated_at = new DateTimeImmutable();
+        $this->resetSlug();
+    }
+
+    public function resetSlug(): void
+    {
+        $this->slug = \bin2hex(\random_bytes(32));
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Case346/Entity/User.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case346/Entity/User.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case346\Entity;
+
+use DateTimeImmutable;
+
+class User
+{
+    public const ROLE = 'user';
+
+    public ?int $id = null;
+    public string $login;
+    public DateTimeImmutable $created_at;
+    public DateTimeImmutable $updated_at;
+    /** @var iterable<Post> */
+    public iterable $posts = [];
+
+    public function __construct(string $login, string $password)
+    {
+        $this->login = $login;
+        $this->created_at = new DateTimeImmutable();
+        $this->updated_at = new DateTimeImmutable();
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Case346/schema.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case346/schema.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\Relation;
+use Cycle\ORM\SchemaInterface as Schema;
+use Cycle\ORM\Select\Source;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case346\Entity\Post;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case346\Entity\User;
+
+return [
+    'post' => [
+        Schema::ENTITY => Post::class,
+        Schema::SOURCE => Source::class,
+        Schema::DATABASE => 'default',
+        Schema::MAPPER => Mapper::class,
+        Schema::TABLE => 'post',
+        Schema::PRIMARY_KEY => ['id'],
+        Schema::FIND_BY_KEYS => ['id'],
+        Schema::COLUMNS => [
+            'id' => 'id',
+            'slug' => 'slug',
+            'title' => 'title',
+            'public' => 'public',
+            'content' => 'content',
+            'created_at' => 'created_at',
+            'updated_at' => 'updated_at',
+            'published_at' => 'published_at',
+            'deleted_at' => 'deleted_at',
+            'user_id' => 'user_id',
+        ],
+        Schema::RELATIONS => [
+            'user' => [
+                Relation::TYPE => Relation::BELONGS_TO,
+                Relation::TARGET => User::ROLE,
+                Relation::LOAD => Relation::LOAD_PROMISE,
+                Relation::SCHEMA => [
+                    Relation::CASCADE => true,
+                    Relation::NULLABLE => true,
+                    Relation::INNER_KEY => 'user_id',
+                    Relation::OUTER_KEY => ['id'],
+                ],
+            ],
+        ],
+        Schema::TYPECAST => [
+            'id' => 'int',
+            'public' => 'bool',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+            'published_at' => 'datetime',
+            'deleted_at' => 'datetime',
+            'user_id' => 'int',
+        ],
+        Schema::SCHEMA => [],
+    ],
+    'user' => [
+        Schema::ENTITY => User::class,
+        Schema::MAPPER => Mapper::class,
+        Schema::SOURCE => Source::class,
+        Schema::DATABASE => 'default',
+        Schema::TABLE => 'user',
+        Schema::PRIMARY_KEY => ['id'],
+        Schema::FIND_BY_KEYS => ['id'],
+        Schema::COLUMNS => [
+            'id' => 'id',
+            'login' => 'login',
+            'created_at' => 'created_at',
+            'updated_at' => 'updated_at',
+        ],
+        Schema::RELATIONS => [
+            // 'posts' => [
+            //     Relation::TYPE => Relation::HAS_MANY,
+            //     Relation::TARGET => 'post',
+            //     Relation::COLLECTION_TYPE => 'array',
+            //     Relation::LOAD => Relation::LOAD_PROMISE,
+            //     Relation::SCHEMA => [
+            //         Relation::CASCADE => true,
+            //         Relation::NULLABLE => false,
+            //         Relation::WHERE => [],
+            //         Relation::ORDER_BY => [],
+            //         Relation::INNER_KEY => ['id'],
+            //         Relation::OUTER_KEY => 'user_id',
+            //     ],
+            // ],
+        ],
+        Schema::SCOPE => null,
+        Schema::TYPECAST => [
+            'id' => 'int',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ],
+        Schema::SCHEMA => [],
+    ],
+];

--- a/tests/ORM/Functional/Driver/MySQL/Integration/Case346/CaseTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Integration/Case346/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\MySQL\Integration\Case346;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case346\CaseTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/ORM/Functional/Driver/Postgres/Integration/Case346/CaseTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Integration/Case346/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Postgres\Integration\Case346;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case346\CaseTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/ORM/Functional/Driver/SQLServer/Integration/Case346/CaseTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Integration/Case346/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLServer\Integration\Case346;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case346\CaseTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/ORM/Functional/Driver/SQLite/Integration/Case346/CaseTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Integration/Case346/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLite\Integration\Case346;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case346\CaseTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,6 +13,9 @@ require dirname(__DIR__) . '/vendor/autoload.php';
 $drivers = [
     'sqlite' => new Config\SQLiteDriverConfig(
         queryCache: true,
+        options:[
+            'logQueryParameters' => true,
+        ],
     ),
     'mysql' => new Config\MySQLDriverConfig(
         connection: new Config\MySQL\TcpConnectionConfig(


### PR DESCRIPTION
## What was changed

Fix #346 

Fixed expected behavior:
If we change parent ID in a BelongsTo relation and store the child entity, the parent entity will be changed in the relation with the new one.

Before it was like this: the nullable BelongsTo relation can't be finished if the parent had loaded state.
