### PR TITLE
Allow doctrine/instantiator 2.x

### DIFF
--- a/.github/workflows/ci-mssql.yml
+++ b/.github/workflows/ci-mssql.yml
@@ -26,7 +26,7 @@ jobs:
             extensions: pdo, pdo_sqlsrv
             mssql: 'server:2019-latest'
           - php: '8.1'
-            extensions: pdo, pdo_sqlsrv-5.10.0beta2
+            extensions: pdo, pdo_sqlsrv-5.11.1
             mssql: 'server:2019-latest'
 
     services:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
           php-version: ${{ matrix.php-version }}
           coverage: pcov
           tools: pecl
-          extensions: mbstring, pdo, pdo_sqlite, pdo_pgsql, pdo_sqlsrv-5.10.0beta2, pdo_mysql
+          extensions: mbstring, pdo, pdo_sqlite, pdo_pgsql, pdo_sqlsrv-5.11.1, pdo_mysql
       - name: Get Composer Cache Directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=8.0",
         "ext-pdo": "*",
         "cycle/database": "^2.3",
-        "doctrine/instantiator": "^1.3.1"
+        "doctrine/instantiator": "^1.3.1 || ^2.0"
     },
     "require-dev": {
         "doctrine/collections": "^1.6 || ^2.0",


### PR DESCRIPTION
### What was changed

1. Allow doctrine/instantiator 2.x. There was one change in the package that broke backward compatibility. Constants `\Doctrine\Instantiator\Instantiator::SERIALIZATION_FORMAT_USE_UNSERIALIZER` and `\Doctrine\Instantiator\Instantiator::SERIALIZATION_FORMAT_AVOID_UNSERIALIZER` have become private. We don't use them.
2. Updated pdo_sqlsrv extension in SQLServer tests