### PR TITLE
Add NullHeap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "php": ">=8.0",
         "ext-pdo": "*",
         "cycle/database": "^2.3",
-        "doctrine/instantiator": "^1.3.1 || ^2.0"
+        "doctrine/instantiator": "^1.3.1 || ^2.0",
+        "spiral/core": "^2.8 || ^3.0"
     },
     "require-dev": {
         "doctrine/collections": "^1.6 || ^2.0",
@@ -18,7 +19,7 @@
         "mockery/mockery": "^1.1",
         "phpunit/phpunit": "^9.5",
         "ramsey/uuid": "^4.0",
-        "spiral/tokenizer": "^2.8",
+        "spiral/tokenizer": "^2.8 || ^3.0",
         "vimeo/psalm": "^4.9"
     },
     "autoload": {

--- a/src/Heap/NullHeap.php
+++ b/src/Heap/NullHeap.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Heap;
+
+/**
+ * NullHeap is a heap implementation that does nothing.
+ * It is useful when you are using ORM only for reading and you don't need to cache the loaded data.
+ *
+ * Effects of using NullHeap:
+ * - Less memory consumption
+ * - No need to clean the heap after each request in long-living applications
+ * - You won't be able to update entities in the database. ORM will consider each loaded entity as newly created.
+ */
+final class NullHeap implements HeapInterface
+{
+    public function has(object $entity): bool
+    {
+        return false;
+    }
+
+    public function get(object $entity): ?Node
+    {
+        return null;
+    }
+
+    public function find(string $role, array $scope): ?object
+    {
+        return null;
+    }
+
+    public function attach(object $entity, Node $node, array $index = []): void
+    {
+    }
+
+    public function detach(object $entity): void
+    {
+    }
+
+    public function clean(): void
+    {
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Typecast/SchemaTest.php
+++ b/tests/ORM/Functional/Driver/Common/Typecast/SchemaTest.php
@@ -88,8 +88,8 @@ final class SchemaTest extends BaseTest
     public function testEmptyStringShouldThrowAnException(): void
     {
         $this->expectException(FactoryTypecastException::class);
-        $this->expectErrorMessage(
-            'Bad typecast handler declaration for the `book` role. Undefined class or binding \'\''
+        $this->expectExceptionMessageMatches(
+            '/Bad typecast handler declaration for the `book` role./'
         );
 
         $this->setUpOrm([
@@ -106,7 +106,7 @@ final class SchemaTest extends BaseTest
         ]);
 
         $this->expectException(FactoryTypecastException::class);
-        $this->expectErrorMessage(
+        $this->expectExceptionMessage(
             'Bad typecast handler declaration for the `book` role. Cycle\ORM\Factory::makeTypecastHandler(): Return value must be of type Cycle\ORM\Parser\TypecastInterface, Cycle\ORM\Tests\Functional\Driver\Common\Typecast\Fixture\InvalidTypecaster returned'
         );
 
@@ -125,7 +125,7 @@ final class SchemaTest extends BaseTest
         ]);
 
         $this->expectException(FactoryTypecastException::class);
-        $this->expectErrorMessage(
+        $this->expectExceptionMessage(
             'Bad typecast handler declaration for the `book` role. Cycle\ORM\Factory::makeTypecastHandler(): Return value must be of type Cycle\ORM\Parser\TypecastInterface, Cycle\ORM\Tests\Functional\Driver\Common\Typecast\Fixture\InvalidTypecaster returned'
         );
 

--- a/tests/ORM/Unit/Heap/NullHeapTest.php
+++ b/tests/ORM/Unit/Heap/NullHeapTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Unit\Heap;
+
+use Cycle\ORM\Heap\HeapInterface;
+use Cycle\ORM\Heap\Node;
+use Cycle\ORM\Heap\NullHeap;
+use Cycle\ORM\Tests\Fixtures\User;
+use PHPUnit\Framework\TestCase;
+
+final class NullHeapTest extends TestCase
+{
+    protected const INDEX_FIELDS_1 = 'id';
+    protected const INDEX_VALUES_1_1 = 42;
+    protected const INDEX_VALUES_1_2 = 24;
+    protected const INDEX_FIND_1_1 = [self::INDEX_FIELDS_1 => self::INDEX_VALUES_1_1];
+    protected const INDEX_FIND_1_2 = [self::INDEX_FIELDS_1 => self::INDEX_VALUES_1_2];
+    protected const INDEX_FIND_1_BAD = [self::INDEX_FIELDS_1 => 404];
+    protected const INDEX_FIELDS_2 = 'email';
+    protected const INDEX_VALUES_2_1 = 'mail1@spiral';
+    protected const INDEX_VALUES_2_2 = 'mail2@spiral';
+    protected const INDEX_FIND_2_1 = [self::INDEX_FIELDS_2 => self::INDEX_VALUES_2_1];
+    protected const INDEX_FIELDS_BAD = 'foo';
+    protected const INDEX_FIND_BAD = [self::INDEX_FIELDS_BAD => null];
+    protected const ENTITY_SET_1 = [
+        self::INDEX_FIELDS_1 => self::INDEX_VALUES_1_1,
+        self::INDEX_FIELDS_2 => self::INDEX_VALUES_2_1,
+    ];
+    protected const ENTITY_SET_2 = [
+        self::INDEX_FIELDS_1 => self::INDEX_VALUES_1_2,
+        self::INDEX_FIELDS_2 => self::INDEX_VALUES_2_2,
+    ];
+
+    public function testAttachAndFind(): void
+    {
+        $heap = $this->createHeap();
+        $node1 = new Node(Node::NEW, self::ENTITY_SET_1, 'user');
+        $entity1 = new User();
+        $node2 = new Node(Node::NEW, self::ENTITY_SET_2, 'user');
+        $entity2 = new User();
+        $heap->attach($entity1, $node1, [self::INDEX_FIELDS_1]);
+        $heap->attach($entity2, $node2, [self::INDEX_FIELDS_1]);
+
+        $this->assertNull($heap->find('user', self::INDEX_FIND_1_2));
+        $this->assertNull($heap->find('user', self::INDEX_FIND_1_BAD));
+        $this->assertNull($heap->find('user', []));
+    }
+
+    public function testIndexAsArray(): void
+    {
+        $heap = $this->createHeap();
+        $node = new Node(Node::NEW, self::ENTITY_SET_1, 'user');
+        $entity = new User();
+        $heap->attach($entity, $node, [(array)self::INDEX_FIELDS_1]);
+
+        $this->assertNull($heap->find('user', self::INDEX_FIND_1_1));
+    }
+
+    public function testFindByNotExistingIndex(): void
+    {
+        $heap = $this->createHeap();
+        $node = new Node(Node::NEW, self::ENTITY_SET_1, 'user');
+        $entity = new User();
+        $heap->attach($entity, $node, [self::INDEX_FIELDS_1]);
+
+        $this->assertNull($heap->find('user', self::INDEX_FIND_2_1));
+    }
+
+    public function testAttachWithEmptyIndex(): void
+    {
+        $heap = $this->createHeap();
+        $node = new Node(Node::NEW, self::ENTITY_SET_1, 'user');
+        $entity = new User();
+        $heap->attach($entity, $node, [[], self::INDEX_FIELDS_1]);
+
+        $this->assertNull($heap->find('user', self::INDEX_FIND_1_1));
+        $this->assertNull($heap->find('user', self::INDEX_FIND_2_1));
+    }
+
+    public function testAttachWithBadIndex(): void
+    {
+        $heap = $this->createHeap();
+        $node = new Node(Node::NEW, self::ENTITY_SET_1, 'user');
+        $entity = new User();
+        $heap->attach($entity, $node, [self::INDEX_FIELDS_BAD, self::INDEX_FIELDS_2]);
+
+        $this->assertNull($heap->find('user', self::INDEX_FIND_BAD));
+        $this->assertNull($heap->find('user', self::INDEX_FIND_2_1));
+
+        // No error
+        $heap->detach($entity);
+    }
+
+    public function testFindWithBadIndex(): void
+    {
+        $heap = $this->createHeap();
+        $node = new Node(Node::NEW, self::ENTITY_SET_1, 'user');
+        $entity = new User();
+        $heap->attach($entity, $node, [self::INDEX_FIELDS_2]);
+
+        $this->assertNull($heap->find('user', self::INDEX_FIND_BAD));
+        $this->assertNull($heap->find('user', self::INDEX_FIND_2_1));
+    }
+
+    public function testFindBadRole(): void
+    {
+        $heap = $this->createHeap();
+
+        $this->assertNull($heap->find('bad_role', self::INDEX_FIND_BAD));
+    }
+
+    public function testFindEmptyCriteria(): void
+    {
+        $heap = $this->createHeap();
+        $node = new Node(Node::NEW, self::ENTITY_SET_1, 'user');
+        $entity = new User();
+        $heap->attach($entity, $node, [self::INDEX_FIELDS_2]);
+
+        $this->assertNull($heap->find('user', []));
+    }
+
+    public function testDetach(): void
+    {
+        $heap = $this->createHeap();
+        $node1 = new Node(Node::NEW, self::INDEX_FIND_1_1, 'user');
+        $entity1 = new User();
+        $node2 = new Node(Node::NEW, self::INDEX_FIND_1_2, 'user');
+        $entity2 = new User();
+        $heap->attach($entity1, $node1, [self::INDEX_FIELDS_1]);
+        $heap->attach($entity2, $node2, [self::INDEX_FIELDS_1]);
+
+        $heap->detach($entity1);
+        $heap->detach($entity2);
+
+        $this->assertNull($heap->find('user', self::INDEX_FIND_1_1));
+        $this->assertNull($heap->find('user', self::INDEX_FIND_1_2));
+        $this->assertFalse($heap->has($entity1));
+        $this->assertFalse($heap->has($entity2));
+    }
+
+    public function testGet(): void
+    {
+        $heap = $this->createHeap();
+        $node1 = new Node(Node::NEW, ['email' => 'test1'], 'user');
+        $entity1 = new User();
+        $node2 = new Node(Node::NEW, self::ENTITY_SET_2, 'user');
+        $entity2 = new User();
+        $heap->attach($entity1, $node1, [self::INDEX_FIELDS_1]);
+        $heap->attach($entity2, $node2, [self::INDEX_FIELDS_1]);
+
+        $this->assertNull($heap->get($entity1));
+        $this->assertNull($heap->get($entity2));
+    }
+
+    public function testClean(): void
+    {
+        $this->createHeap()->clean();
+
+        $this->assertTrue(true, 'There are no exceptions');
+    }
+
+    protected function createHeap(): HeapInterface
+    {
+        return new NullHeap();
+    }
+}

--- a/tests/ORM/Unit/Mapper/Proxy/ProxyEntityFactoryTest.php
+++ b/tests/ORM/Unit/Mapper/Proxy/ProxyEntityFactoryTest.php
@@ -60,7 +60,7 @@ class ProxyEntityFactoryTest extends TestCase
     public function testCreatesNonExistingObjectShouldThrowException()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectErrorMessage(
+        $this->expectExceptionMessage(
             'The entity `hello-world` class does not exist. Proxy factory can not create classless entities.'
         );
 


### PR DESCRIPTION
NullHeap is a heap implementation that does nothing.
It is useful when you are using ORM only for reading and you don't need to cache the loaded data.

Effects of using NullHeap:
- Less memory consumption
- No need to clean the heap after each request in long-living applications
- You won't be able to update entities in the database. ORM will consider each loaded entity as newly created.

Fix #419