### PR TITLE
Expose support for multiple `with` on same relation

### DIFF
--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -43,6 +43,9 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
+      - name: Show databases for root user
+        run: mysql --protocol=tcp -h localhost -P 13306 -u root -proot -e "ALTER DATABASE spiral CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "phpunit/phpunit": "^9.5",
         "ramsey/uuid": "^4.0",
         "spiral/tokenizer": "^2.8 || ^3.0",
+        "symfony/var-dumper": "^5.2 || ^6.0 || ^7.0",
         "vimeo/psalm": "5.21"
     },
     "autoload": {

--- a/src/Select.php
+++ b/src/Select.php
@@ -397,6 +397,7 @@ class Select implements IteratorAggregate, Countable, PaginableInterface
      * ```
      *
      * @return static<TEntity>
+     *
      * @see load()
      */
     public function with(string|array $relation, array $options = []): self

--- a/src/Select.php
+++ b/src/Select.php
@@ -375,25 +375,20 @@ class Select implements IteratorAggregate, Countable, PaginableInterface
      *             ->load('comments', ['using' => 'commentsR']);
      * ```
      *
-     * To use `with` twice on the same relation you can use `alias` option.
+     * To use with() twice on the same relation, you can use `alias` option.
      * ```php
      * Country::find()
      *     // Find all translations
      *     ->with('translations', [ 'as' => 'trans'])
-     *     ->where(function (QueryBuilder $qb): void {
-     *         $searchProperties = ['code', 'name', 'trans.title'];
-     *         foreach ($searchProperties as $propertyName) {
-     *             $qb->orWhere($propertyName, 'LIKE', '%eng%');
-     *         }
-     *     })
      *     ->load('translations', ['using' => 'trans'])
-     *     // Second `with`
+     *     // Second `with` for sorting only
      *     ->with('translations', [
-     *         'as' => 'comments2', // Alias for SQL
-     *         'alias' => 'comments_sort', // Alias for ORM to not overwrite previous `with` call
+     *         'as' => 'transEn', // Alias for SQL
+     *         'alias' => 'translations-en', // Alias for ORM to not to overwrite previous `with`
      *         'method' => JoinableLoader::LEFT_JOIN,
-     *         'where' => ['author_id' => $id],
-     *     ]);
+     *         'where' => ['locale' => 'en'],
+     *     ])
+     *     ->orderBy('transEn.title', 'ASC');
      * ```
      *
      * @return static<TEntity>

--- a/src/Select.php
+++ b/src/Select.php
@@ -306,58 +306,98 @@ class Select implements IteratorAggregate, Countable, PaginableInterface
      *
      * Examples:
      *
-     * // Find all users who have comments comments
+     * Find all users who have comments comments
+     * ```php
      * User::find()->with('comments');
+     * ```
      *
-     * // Find all users who have approved comments (we can use comments table alias in where
-     * statement). User::find()->with('comments')->where('comments.approved', true);
+     * Find all users who have approved comments (we can use comments table alias in where statement)
+     * ```php
+     * User::find()->with('comments')->where('comments.approved', true);
+     * ```
      *
-     * // Find all users who have posts which have approved comments
+     * Find all users who have posts which have approved comments
+     * ```php
      * User::find()->with('posts.comments')->where('posts_comments.approved', true);
+     * ```
      *
-     * // Custom join alias for post comments relation
+     * Custom join alias for post comments relation
+     * ```php
      * $user->with('posts.comments', [
      *      'as' => 'comments'
      * ])->where('comments.approved', true);
+     * ```
      *
-     * // If you joining MANY_TO_MANY relation you will be able to use pivot table used as relation
-     * // name plus "_pivot" postfix. Let's load all users with approved tags.
+     * If you joining MANY_TO_MANY relation you will be able to use pivot table used as relation
+     * name plus "_pivot" postfix. Let's load all users with approved tags.
+     * ```php
      * $user->with('tags')->where('tags_pivot.approved', true);
+     * ```
      *
-     * // You can also use custom alias for pivot table as well
+     * You can also use custom alias for pivot table as well
+     * ```php
      * User::find()->with('tags', [
      *      'pivotAlias' => 'tags_connection'
      * ])
      * ->where('tags_connection.approved', false);
+     * ```
      *
      * You can safely combine with() and load() methods.
      *
-     * // Load all users with approved comments and pre-load all their comments
+     * Load all users with approved comments and pre-load all their comments
+     * ```php
      * User::find()->with('comments')->where('comments.approved', true)->load('comments');
+     * ```
      *
-     * // You can also use custom conditions in this case, let's find all users with approved
-     * // comments and pre-load such approved comments
-     * User::find()->with('comments')->where('comments.approved', true)
+     * You can also use custom conditions in this case, let's find all users with approved
+     * comments and pre-load such approved comments
+     * ```php
+     * User::find()->with('comments')
+     *             ->where('comments.approved', true)
      *             ->load('comments', [
      *                  'where' => ['{@}.approved' => true]
      *              ]);
+     * ```
      *
-     * // As you might notice previous construction will create 2 queries, however we can simplify
-     * // this construction to use already joined table as source of data for relation via "using"
-     * // keyword
+     * As you might notice previous construction will create 2 queries, however we can simplify
+     * this construction to use already joined table as source of data for relation via "using" keyword
+     * ```php
      * User::find()->with('comments')
      *             ->where('comments.approved', true)
      *             ->load('comments', ['using' => 'comments']);
+     * ```
      *
-     * // You will get only one query with INNER JOIN, to better understand this example let's use
-     * // custom alias for comments in with() method.
+     * You will get only one query with INNER JOIN, to better understand this example let's use
+     * custom alias for comments in with() method.
+     * ```php
      * User::find()->with('comments', ['as' => 'commentsR'])
      *             ->where('commentsR.approved', true)
      *             ->load('comments', ['using' => 'commentsR']);
+     * ```
      *
-     * @see load()
+     * To use `with` twice on the same relation you can use `alias` option.
+     * ```php
+     * Country::find()
+     *     // Find all translations
+     *     ->with('translations', [ 'as' => 'trans'])
+     *     ->where(function (QueryBuilder $qb): void {
+     *         $searchProperties = ['code', 'name', 'trans.title'];
+     *         foreach ($searchProperties as $propertyName) {
+     *             $qb->orWhere($propertyName, 'LIKE', '%eng%');
+     *         }
+     *     })
+     *     ->load('translations', ['using' => 'trans'])
+     *     // Second `with`
+     *     ->with('translations', [
+     *         'as' => 'comments2', // Alias for SQL
+     *         'alias' => 'comments_sort', // Alias for ORM to not overwrite previous `with` call
+     *         'method' => JoinableLoader::LEFT_JOIN,
+     *         'where' => ['author_id' => $id],
+     *     ]);
+     * ```
      *
      * @return static<TEntity>
+     * @see load()
      */
     public function with(string|array $relation, array $options = []): self
     {

--- a/src/Select/AbstractLoader.php
+++ b/src/Select/AbstractLoader.php
@@ -189,6 +189,7 @@ abstract class AbstractLoader implements LoaderInterface
 
         $relation = $this->resolvePath($relation);
         $alias ??= $options['alias'] ?? $relation;
+        unset($options['alias']);
         if (!empty($options['as'])) {
             // ??
             $this->registerPath($options['as'], $alias);

--- a/src/Select/AbstractLoader.php
+++ b/src/Select/AbstractLoader.php
@@ -175,24 +175,28 @@ abstract class AbstractLoader implements LoaderInterface
         string|LoaderInterface $relation,
         array $options,
         bool $join = false,
-        bool $load = false
+        bool $load = false,
     ): LoaderInterface {
         if ($relation instanceof ParentLoader) {
             return $this->inherit = $relation->withContext($this);
         }
+
         if ($relation instanceof SubclassLoader) {
             $loader = $relation->withContext($this);
             $this->subclasses[] = $loader;
             return $loader;
         }
+
         $relation = $this->resolvePath($relation);
+        $alias ??= $options['alias'] ?? $relation;
         if (!empty($options['as'])) {
-            $this->registerPath($options['as'], $relation);
+            // ??
+            $this->registerPath($options['as'], $alias);
         }
 
-        //Check if relation contain dot, i.e. relation chain
+        // Check if relation contain dot, i.e. relation chain
         if ($this->isChain($relation)) {
-            return $this->loadChain($relation, $options, $join, $load);
+            return $this->loadChain($relation, $options, $join, $load, $alias);
         }
 
         /*
@@ -210,8 +214,8 @@ abstract class AbstractLoader implements LoaderInterface
         }
 
         if (isset($loaders[$relation])) {
-            // overwrite existing loader options
-            return $loaders[$relation] = $loaders[$relation]->withContext($this, $options);
+            // Overwrite existing loader options
+            return $loaders[$alias] = $loaders[$alias]->withContext($this, $options);
         }
 
         if ($join) {
@@ -222,7 +226,7 @@ abstract class AbstractLoader implements LoaderInterface
         }
 
         try {
-            //Creating new loader.
+            // Creating new loader.
             $loader = $this->factory->loader(
                 $this->ormSchema,
                 $this->sourceProvider,
@@ -231,7 +235,7 @@ abstract class AbstractLoader implements LoaderInterface
             );
         } catch (SchemaException | FactoryException $e) {
             if ($this->inherit instanceof self) {
-                return $this->inherit->loadRelation($relation, $options, $join, $load);
+                return $this->inherit->loadRelation($relation, $options, $join, $load, $alias);
             }
             throw new LoaderException(
                 sprintf('Unable to create loader: %s', $e->getMessage()),
@@ -240,7 +244,7 @@ abstract class AbstractLoader implements LoaderInterface
             );
         }
 
-        return $loaders[$relation] = $loader->withContext($this, $options);
+        return $loaders[$alias] = $loader->withContext($this, $options);
     }
 
     public function createNode(): AbstractNode

--- a/src/Select/Loader/ManyToManyLoader.php
+++ b/src/Select/Loader/ManyToManyLoader.php
@@ -92,7 +92,7 @@ class ManyToManyLoader extends JoinableLoader
         string|LoaderInterface $relation,
         array $options,
         bool $join = false,
-        bool $load = false
+        bool $load = false,
     ): LoaderInterface {
         if ($relation === '@' || $relation === '@.@') {
             unset($options['method']);

--- a/src/Select/Traits/ChainTrait.php
+++ b/src/Select/Traits/ChainTrait.php
@@ -17,7 +17,7 @@ trait ChainTrait
         string|LoaderInterface $relation,
         array $options,
         bool $join = false,
-        bool $load = false
+        bool $load = false,
     ): LoaderInterface;
 
     /**

--- a/tests/ORM/Functional/Driver/Common/BaseTest.php
+++ b/tests/ORM/Functional/Driver/Common/BaseTest.php
@@ -83,13 +83,6 @@ abstract class BaseTest extends TestCase
             $this->logger->display();
         }
 
-        $this->logger = new TestLogger();
-        $this->getDriver()->setLogger($this->logger);
-
-        if (self::$config['debug']) {
-            $this->logger->display();
-        }
-
         $this->orm = new ORM(
             (new Factory(
                 $this->dbal,

--- a/tests/ORM/Functional/Driver/Common/Integration/Issue482/AbstractTestCase.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Issue482/AbstractTestCase.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482;
+
+use Cycle\ORM\Select;
+use Cycle\ORM\Select\QueryBuilder;
+use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\IntegrationTestTrait;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\Entity\Country;
+use Cycle\ORM\Tests\Traits\TableTrait;
+
+abstract class AbstractTestCase extends BaseTest
+{
+    use IntegrationTestTrait;
+    use TableTrait;
+
+    public function setUp(): void
+    {
+        // Init DB
+        parent::setUp();
+        $this->makeTables();
+        $this->fillData();
+
+        $this->loadSchema(__DIR__ . '/schema.php');
+    }
+
+    public function testSelect(): void
+    {
+        $select = $this->orm->getRepository(Country::class)
+            ->select()
+            ->where('is_friendly', true)
+            // User wants to search everywhere
+            ->with('translations', [
+                'as' => 'trans',
+                'method' => 4, //JoinableLoader::LEFT_JOIN
+                'alias' => 'trans1',
+            ])
+            // User wants to search everywhere
+            ->where(function (QueryBuilder $qb): void {
+                $searchProperties = ['code', 'name', 'trans.title'];
+                foreach ($searchProperties as $propertyName) {
+                    $qb->orWhere($propertyName, 'LIKE', "%eng%");
+                }
+            })
+            // User want to sort by translation
+            ->with('translations', [
+                'as' => 'transEn',
+                'method' => 4, //JoinableLoader::LEFT_JOIN
+                'where' => [
+                    'locale_id' => 1,
+                ],
+                'alias' => 'trans2',
+            ])
+            ->orderBy('transEn.title', 'asc')
+            ->load('translations', [
+                'using' => 'trans',
+            ]);
+
+        $this->assertExpectedSql($select);
+
+        $data = $select->fetchData();
+        $this->assertCount(3, $data);
+        $this->assertEquals(
+            [
+                'America on english',
+                'China on english',
+                'Russia on english',
+            ],
+            \array_column(
+                \array_merge(
+                    ...\array_column($data, 'translations')
+                ),
+                'title'
+            )
+        );
+
+        $all = $select->fetchAll();
+        $this->assertCount(3, $all);
+        $this->assertEquals(
+            [
+                'America on english',
+                'China on english',
+                'Russia on english',
+            ],
+            \array_map(
+                static function (Country $c) {
+                    self::assertCount(1, $c->translations);
+                    return $c->translations[0]->title;
+                },
+                $all
+            )
+        );
+    }
+
+    private function makeTables(): void
+    {
+        // Make tables
+        $this->makeTable('country', [
+            'id' => 'primary', // autoincrement
+            'name' => 'string',
+            'code' => 'string',
+            'is_friendly' => 'bool',
+        ]);
+
+        $this->makeTable('locale', [
+            'id' => 'primary',
+            'code' => 'string',
+        ]);
+
+        $this->makeTable('translation', [
+            'id' => 'primary',
+            'title' => 'string',
+            'country_id' => 'int',
+            'locale_id' => 'int',
+        ]);
+        $this->makeFK('translation', 'country_id', 'country', 'id', 'NO ACTION', 'NO ACTION');
+        $this->makeFK('translation', 'locale_id', 'locale', 'id', 'NO ACTION', 'NO ACTION');
+    }
+
+    private function fillData(): void
+    {
+        $this->getDatabase()->table('translation')->delete()->run();
+        $this->getDatabase()->table('country')->delete()->run();
+        $this->getDatabase()->table('locale')->delete()->run();
+
+        $en = 1;
+        $this->getDatabase()->table('locale')->insertMultiple(
+            ['code'],
+            [
+                ['en'],
+            ],
+        );
+        $this->getDatabase()->table('country')->insertMultiple(
+            ['name', 'code', 'is_friendly'],
+            [
+                ['Russia', 'RUS', true],
+                ['USA', 'USA', true],
+                ['China', 'CHN', true],
+            ],
+        );
+
+        $this->getDatabase()->table('translation')->insertMultiple(
+            ['country_id', 'locale_id', 'title'],
+            [
+                [1, $en, 'Russia on english'],
+                [2, $en, 'America on english'],
+                [3, $en, 'China on english'],
+            ],
+        );
+    }
+
+    abstract protected function assertExpectedSql(Select $select): void;
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Issue482/AbstractTestCase.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Issue482/AbstractTestCase.php
@@ -41,7 +41,7 @@ abstract class AbstractTestCase extends BaseTest
             ->where(function (QueryBuilder $qb): void {
                 $searchProperties = ['code', 'name', 'trans.title'];
                 foreach ($searchProperties as $propertyName) {
-                    $qb->orWhere($propertyName, 'LIKE', "%eng%");
+                    $qb->orWhere($propertyName, 'LIKE', '%eng%');
                 }
             })
             // User want to sort by translation

--- a/tests/ORM/Functional/Driver/Common/Integration/Issue482/AbstractTestCase.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Issue482/AbstractTestCase.php
@@ -94,6 +94,25 @@ abstract class AbstractTestCase extends BaseTest
         );
     }
 
+    protected function assertExpectedSql(Select $select): void
+    {
+        $actual = $select->buildQuery()->sqlStatement();
+        $expected = <<<SQL
+            SELECT `country`.`id` AS `c0`, `country`.`name` AS `c1`, `country`.`code` AS `c2`, `country`.`is_friendly` AS `c3`
+            FROM `country` AS `country`
+            LEFT JOIN `translation` AS `trans`
+                ON `trans`.`country_id` = `country`.`id`
+            LEFT JOIN `translation` AS `transEn`
+                ON `transEn`.`country_id` = `country`.`id` AND `transEn`.`locale_id` = 1
+            WHERE `country`.`is_friendly` = TRUE AND (`country`.`code` LIKE '%eng%' OR `country`.`name` LIKE '%eng%' OR `trans`.`title` LIKE '%eng%'  )
+            ORDER BY `transEn`.`title` ASC
+            SQL;
+        $this->assertEquals(
+            \array_map('trim', \explode($actual, PHP_EOL)),
+            \array_map('trim', \explode($expected, PHP_EOL))
+        );
+    }
+
     private function makeTables(): void
     {
         // Make tables
@@ -150,6 +169,4 @@ abstract class AbstractTestCase extends BaseTest
             ],
         );
     }
-
-    abstract protected function assertExpectedSql(Select $select): void;
 }

--- a/tests/ORM/Functional/Driver/Common/Integration/Issue482/Entity/Country.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Issue482/Entity/Country.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\Entity;
+
+class Country
+{
+    public ?int $id = null;
+    public string $name;
+    public string $code;
+    public bool $isFriendly = true;
+
+    /** @var iterable<Translation> */
+    public iterable $translations = [];
+
+    public function __construct(string $name, string $code)
+    {
+        $this->name = $name;
+        $this->code = $code;
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Issue482/Entity/Locale.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Issue482/Entity/Locale.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\Entity;
+
+class Locale
+{
+    public ?int $id = null;
+    public string $code;
+
+    /** @var iterable<Translation> */
+    public iterable $translations = [];
+
+    public function __construct(string $code)
+    {
+        $this->code = $code;
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Issue482/Entity/Translation.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Issue482/Entity/Translation.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\Entity;
 
-
 class Translation
 {
     public ?int $id = null;

--- a/tests/ORM/Functional/Driver/Common/Integration/Issue482/Entity/Translation.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Issue482/Entity/Translation.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\Entity;
+
+
+class Translation
+{
+    public ?int $id = null;
+    public Country $country;
+    public Locale $locale;
+    public string $title;
+
+    public function __construct(Country $country, Locale $locale, string $title)
+    {
+        $this->country = $country;
+        $this->locale = $locale;
+        $this->title = $title;
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Issue482/schema.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Issue482/schema.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\Relation;
+use Cycle\ORM\SchemaInterface as Schema;
+use Cycle\ORM\Select\Repository;
+use Cycle\ORM\Select\Source;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\Entity\Translation;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\Entity\Country;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\Entity\Locale;
+
+return [
+    'country' => [
+        Schema::ENTITY => Country::class,
+        Schema::SOURCE => Source::class,
+        Schema::DATABASE => 'default',
+        Schema::MAPPER => Mapper::class,
+        Schema::TABLE => 'country',
+        Schema::PRIMARY_KEY => ['id'],
+        Schema::FIND_BY_KEYS => ['id'],
+        Schema::COLUMNS => [
+            'id' => 'id',
+            'name' => 'name',
+            'code' => 'code',
+            'isFriendly' => 'is_friendly',
+        ],
+        Schema::RELATIONS => [
+            'translations' => [
+                Relation::TYPE => Relation::HAS_MANY,
+                Relation::TARGET => 'translation',
+                Relation::COLLECTION_TYPE => 'array',
+                Relation::LOAD => Relation::LOAD_PROMISE,
+                Relation::SCHEMA => [
+                    Relation::CASCADE => true,
+                    Relation::NULLABLE => false,
+                    Relation::WHERE => [],
+                    Relation::ORDER_BY => [],
+                    Relation::INNER_KEY => ['id'],
+                    Relation::OUTER_KEY => 'country_id',
+                ],
+            ],
+        ],
+        Schema::TYPECAST => [
+            'id' => 'int',
+            'name' => 'string',
+            'code' => 'string',
+            'isFriendly' => 'bool',
+        ],
+        Schema::SCHEMA => [],
+    ],
+    'translation' => [
+        Schema::ENTITY => Translation::class,
+        Schema::SOURCE => Source::class,
+        Schema::DATABASE => 'default',
+        Schema::TABLE => 'translation',
+        Schema::PRIMARY_KEY => ['id'],
+        Schema::FIND_BY_KEYS => ['id'],
+        Schema::COLUMNS => [
+            'id' => 'id',
+            'country_id' => 'country_id',
+            'locale_id' => 'locale_id',
+            'title' => 'title',
+        ],
+        Schema::RELATIONS => [
+            'country' => [
+                Relation::TYPE => Relation::BELONGS_TO,
+                Relation::TARGET => 'country',
+                Relation::LOAD => Relation::LOAD_EAGER,
+                Relation::SCHEMA => [
+                    Relation::CASCADE => true,
+                    Relation::NULLABLE => false,
+                    Relation::INNER_KEY => 'country_id',
+                    Relation::OUTER_KEY => ['id'],
+                ],
+            ],
+            'locale' => [
+                Relation::TYPE => Relation::BELONGS_TO,
+                Relation::TARGET => 'locale',
+                Relation::LOAD => Relation::LOAD_PROMISE,
+                Relation::SCHEMA => [
+                    Relation::CASCADE => true,
+                    Relation::NULLABLE => false,
+                    Relation::INNER_KEY => 'locale_id',
+                    Relation::OUTER_KEY => ['id'],
+                ],
+            ],
+        ],
+        Schema::TYPECAST => [
+            'id' => 'int',
+            'country_id' => 'int',
+            'locale_id' => 'int',
+            'title' => 'string',
+        ],
+        Schema::SCHEMA => [],
+    ],
+    'locale' => [
+        Schema::ENTITY => Locale::class,
+        Schema::MAPPER => Mapper::class,
+        Schema::SOURCE => Source::class,
+        Schema::REPOSITORY => Repository::class,
+        Schema::DATABASE => 'default',
+        Schema::TABLE => 'locale',
+        Schema::PRIMARY_KEY => ['id'],
+        Schema::FIND_BY_KEYS => ['id'],
+        Schema::COLUMNS => [
+            'id' => 'id',
+            'code' => 'code',
+        ],
+        Schema::RELATIONS => [
+            'translations' => [
+                Relation::TYPE => Relation::HAS_MANY,
+                Relation::TARGET => 'translation',
+                Relation::COLLECTION_TYPE => 'array',
+                Relation::LOAD => Relation::LOAD_PROMISE,
+                Relation::SCHEMA => [
+                    Relation::CASCADE => true,
+                    Relation::NULLABLE => false,
+                    Relation::WHERE => [],
+                    Relation::ORDER_BY => [],
+                    Relation::INNER_KEY => ['id'],
+                    Relation::OUTER_KEY => 'locale_id',
+                ],
+            ],
+        ],
+        Schema::SCOPE => null,
+        Schema::TYPECAST => [
+            'id' => 'int',
+            'code' => 'string',
+        ],
+        Schema::SCHEMA => [],
+    ],
+];

--- a/tests/ORM/Functional/Driver/MySQL/Integration/Issue482/CaseTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Integration/Issue482/CaseTest.php
@@ -15,23 +15,4 @@ use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCa
 class CaseTest extends AbstractTestCase
 {
     public const DRIVER = 'mysql';
-
-    protected function assertExpectedSql(Select $select): void
-    {
-        $actual = (string)$select->buildQuery();
-        $expected = <<<SQL
-SELECT `country`.`id` AS `c0`, `country`.`name` AS `c1`, `country`.`code` AS `c2`, `country`.`is_friendly` AS `c3`
-FROM `country` AS `country`
-LEFT JOIN `translation` AS `trans`
-    ON `trans`.`country_id` = `country`.`id`
-LEFT JOIN `translation` AS `transEn`
-    ON `transEn`.`country_id` = `country`.`id` AND `transEn`.`locale_id` = 1
-WHERE `country`.`is_friendly` = TRUE AND (`country`.`code` LIKE '%eng%' OR `country`.`name` LIKE '%eng%' OR `trans`.`title` LIKE '%eng%'  )
-ORDER BY `transEn`.`title` ASC
-SQL;
-        $this->assertEquals(
-            \array_map('trim', \explode($actual, PHP_EOL)),
-            \array_map('trim', \explode($expected, PHP_EOL))
-        );
-    }
 }

--- a/tests/ORM/Functional/Driver/MySQL/Integration/Issue482/CaseTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Integration/Issue482/CaseTest.php
@@ -14,4 +14,19 @@ use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCa
 class CaseTest extends AbstractTestCase
 {
     public const DRIVER = 'mysql';
+
+    protected function getExpectedSql(): string
+    {
+        return <<<SQL
+            SELECT `country`.`id` AS `c0`, `country`.`name` AS `c1`, `country`.`code` AS `c2`, `country`.`is_friendly` AS `c3`, `trans`.`id` AS `c4`, `trans`.`country_id` AS `c5`, `trans`.`locale_id`
+            AS `c6`, `trans`.`title` AS `c7`
+            FROM `country` AS `country`
+            LEFT JOIN `translation` AS `trans`
+                ON `trans`.`country_id` = `country`.`id`
+            LEFT JOIN `translation` AS `transEn`
+                ON `transEn`.`country_id` = `country`.`id` AND `transEn`.`locale_id` = 1
+            WHERE `country`.`is_friendly` = TRUE AND (`country`.`code` LIKE '%eng%' OR `country`.`name` LIKE '%eng%' OR `trans`.`title` LIKE '%eng%'  )
+            ORDER BY `transEn`.`title` ASC
+            SQL;
+    }
 }

--- a/tests/ORM/Functional/Driver/MySQL/Integration/Issue482/CaseTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Integration/Issue482/CaseTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Cycle\ORM\Tests\Functional\Driver\MySQL\Integration\Issue482;
 
 // phpcs:ignore
-use Cycle\ORM\Select;
 use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCase;
 
 /**

--- a/tests/ORM/Functional/Driver/MySQL/Integration/Issue482/CaseTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Integration/Issue482/CaseTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\MySQL\Integration\Issue482;
+
+// phpcs:ignore
+use Cycle\ORM\Select;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCase;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class CaseTest extends AbstractTestCase
+{
+    public const DRIVER = 'mysql';
+
+    protected function assertExpectedSql(Select $select): void
+    {
+        $actual = (string)$select->buildQuery();
+        $expected = <<<SQL
+SELECT `country`.`id` AS `c0`, `country`.`name` AS `c1`, `country`.`code` AS `c2`, `country`.`is_friendly` AS `c3`
+FROM `country` AS `country`
+LEFT JOIN `translation` AS `trans`
+    ON `trans`.`country_id` = `country`.`id`
+LEFT JOIN `translation` AS `transEn`
+    ON `transEn`.`country_id` = `country`.`id` AND `transEn`.`locale_id` = 1
+WHERE `country`.`is_friendly` = TRUE AND (`country`.`code` LIKE '%eng%' OR `country`.`name` LIKE '%eng%' OR `trans`.`title` LIKE '%eng%'  )
+ORDER BY `transEn`.`title` ASC
+SQL;
+        $this->assertEquals(
+            \array_map('trim', \explode($actual, PHP_EOL)),
+            \array_map('trim', \explode($expected, PHP_EOL))
+        );
+    }
+}

--- a/tests/ORM/Functional/Driver/Postgres/Integration/Issue482/CaseTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Integration/Issue482/CaseTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Cycle\ORM\Tests\Functional\Driver\Postgres\Integration\Issue482;
 
 // phpcs:ignore
-use Cycle\ORM\Select;
 use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCase;
 
 /**

--- a/tests/ORM/Functional/Driver/Postgres/Integration/Issue482/CaseTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Integration/Issue482/CaseTest.php
@@ -15,23 +15,4 @@ use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCa
 class CaseTest extends AbstractTestCase
 {
     public const DRIVER = 'postgres';
-
-    protected function assertExpectedSql(Select $select): void
-    {
-        $actual = (string)$select->buildQuery();
-        $expected = <<<SQL
-SELECT `country`.`id` AS `c0`, `country`.`name` AS `c1`, `country`.`code` AS `c2`, `country`.`is_friendly` AS `c3`
-FROM `country` AS `country`
-LEFT JOIN `translation` AS `trans`
-    ON `trans`.`country_id` = `country`.`id`
-LEFT JOIN `translation` AS `transEn`
-    ON `transEn`.`country_id` = `country`.`id` AND `transEn`.`locale_id` = 1
-WHERE `country`.`is_friendly` = TRUE AND (`country`.`code` LIKE '%eng%' OR `country`.`name` LIKE '%eng%' OR `trans`.`title` LIKE '%eng%'  )
-ORDER BY `transEn`.`title` ASC
-SQL;
-        $this->assertEquals(
-            \array_map('trim', \explode($actual, PHP_EOL)),
-            \array_map('trim', \explode($expected, PHP_EOL))
-        );
-    }
 }

--- a/tests/ORM/Functional/Driver/Postgres/Integration/Issue482/CaseTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Integration/Issue482/CaseTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Postgres\Integration\Issue482;
+
+// phpcs:ignore
+use Cycle\ORM\Select;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCase;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class CaseTest extends AbstractTestCase
+{
+    public const DRIVER = 'postgres';
+
+    protected function assertExpectedSql(Select $select): void
+    {
+        $actual = (string)$select->buildQuery();
+        $expected = <<<SQL
+SELECT `country`.`id` AS `c0`, `country`.`name` AS `c1`, `country`.`code` AS `c2`, `country`.`is_friendly` AS `c3`
+FROM `country` AS `country`
+LEFT JOIN `translation` AS `trans`
+    ON `trans`.`country_id` = `country`.`id`
+LEFT JOIN `translation` AS `transEn`
+    ON `transEn`.`country_id` = `country`.`id` AND `transEn`.`locale_id` = 1
+WHERE `country`.`is_friendly` = TRUE AND (`country`.`code` LIKE '%eng%' OR `country`.`name` LIKE '%eng%' OR `trans`.`title` LIKE '%eng%'  )
+ORDER BY `transEn`.`title` ASC
+SQL;
+        $this->assertEquals(
+            \array_map('trim', \explode($actual, PHP_EOL)),
+            \array_map('trim', \explode($expected, PHP_EOL))
+        );
+    }
+}

--- a/tests/ORM/Functional/Driver/Postgres/Integration/Issue482/CaseTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Integration/Issue482/CaseTest.php
@@ -14,4 +14,19 @@ use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCa
 class CaseTest extends AbstractTestCase
 {
     public const DRIVER = 'postgres';
+
+    protected function getExpectedSql(): string
+    {
+        return <<<SQL
+            SELECT "country"."id" AS "c0", "country"."name" AS "c1", "country"."code" AS "c2", "country"."is_friendly" AS "c3", "trans"."id" AS "c4", "trans"."country_id" AS "c5", "trans"."locale_id"
+            AS "c6", "trans"."title" AS "c7"
+            FROM "country" AS "country"
+            LEFT JOIN "translation" AS "trans"
+                ON "trans"."country_id" = "country"."id"
+            LEFT JOIN "translation" AS "transEn"
+                ON "transEn"."country_id" = "country"."id" AND "transEn"."locale_id" = 1
+            WHERE "country"."is_friendly" = TRUE AND ("country"."code" LIKE '%eng%' OR "country"."name" LIKE '%eng%' OR "trans"."title" LIKE '%eng%'  )
+            ORDER BY "transEn"."title" ASC
+            SQL;
+    }
 }

--- a/tests/ORM/Functional/Driver/SQLServer/Integration/Issue482/CaseTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Integration/Issue482/CaseTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLServer\Integration\Issue482;
+
+// phpcs:ignore
+use Cycle\ORM\Select;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCase;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class CaseTest extends AbstractTestCase
+{
+    public const DRIVER = 'sqlserver';
+
+    protected function assertExpectedSql(Select $select): void
+    {
+    }
+}

--- a/tests/ORM/Functional/Driver/SQLServer/Integration/Issue482/CaseTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Integration/Issue482/CaseTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Cycle\ORM\Tests\Functional\Driver\SQLServer\Integration\Issue482;
 
 // phpcs:ignore
-use Cycle\ORM\Select;
 use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCase;
 
 /**

--- a/tests/ORM/Functional/Driver/SQLServer/Integration/Issue482/CaseTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Integration/Issue482/CaseTest.php
@@ -14,4 +14,19 @@ use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCa
 class CaseTest extends AbstractTestCase
 {
     public const DRIVER = 'sqlserver';
+
+    protected function getExpectedSql(): string
+    {
+        return <<<SQL
+            SELECT [country].[id] AS [c0], [country].[name] AS [c1], [country].[code] AS [c2], [country].[is_friendly] AS [c3], [trans].[id] AS [c4], [trans].[country_id] AS [c5], [trans].[locale_id]
+            AS [c6], [trans].[title] AS [c7]
+            FROM [country] AS [country]
+            LEFT JOIN [translation] AS [trans]
+                ON [trans].[country_id] = [country].[id]
+            LEFT JOIN [translation] AS [transEn]
+                ON [transEn].[country_id] = [country].[id] AND [transEn].[locale_id] = 1
+            WHERE [country].[is_friendly] = TRUE AND ([country].[code] LIKE '%eng%' OR [country].[name] LIKE '%eng%' OR [trans].[title] LIKE '%eng%'  )
+            ORDER BY [transEn].[title] ASC
+            SQL;
+    }
 }

--- a/tests/ORM/Functional/Driver/SQLServer/Integration/Issue482/CaseTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Integration/Issue482/CaseTest.php
@@ -15,8 +15,4 @@ use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCa
 class CaseTest extends AbstractTestCase
 {
     public const DRIVER = 'sqlserver';
-
-    protected function assertExpectedSql(Select $select): void
-    {
-    }
 }

--- a/tests/ORM/Functional/Driver/SQLite/Integration/Issue482/CaseTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Integration/Issue482/CaseTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Cycle\ORM\Tests\Functional\Driver\SQLite\Integration\Issue482;
 
 // phpcs:ignore
-use Cycle\ORM\Select;
 use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCase;
 
 /**

--- a/tests/ORM/Functional/Driver/SQLite/Integration/Issue482/CaseTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Integration/Issue482/CaseTest.php
@@ -14,4 +14,19 @@ use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCa
 class CaseTest extends AbstractTestCase
 {
     public const DRIVER = 'sqlite';
+
+    protected function getExpectedSql(): string
+    {
+        return <<<SQL
+            SELECT "country"."id" AS "c0", "country"."name" AS "c1", "country"."code" AS "c2", "country"."is_friendly" AS "c3", "trans"."id" AS "c4", "trans"."country_id" AS "c5", "trans"."locale_id"
+            AS "c6", "trans"."title" AS "c7"
+            FROM "country" AS "country"
+            LEFT JOIN "translation" AS "trans"
+                ON "trans"."country_id" = "country"."id"
+            LEFT JOIN "translation" AS "transEn"
+                ON "transEn"."country_id" = "country"."id" AND "transEn"."locale_id" = 1
+            WHERE "country"."is_friendly" = TRUE AND ("country"."code" LIKE '%eng%' OR "country"."name" LIKE '%eng%' OR "trans"."title" LIKE '%eng%'  )
+            ORDER BY "transEn"."title" ASC
+            SQL;
+    }
 }

--- a/tests/ORM/Functional/Driver/SQLite/Integration/Issue482/CaseTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Integration/Issue482/CaseTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLite\Integration\Issue482;
+
+// phpcs:ignore
+use Cycle\ORM\Select;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCase;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class CaseTest extends AbstractTestCase
+{
+    public const DRIVER = 'sqlite';
+
+    protected function assertExpectedSql(Select $select): void
+    {
+    }
+}

--- a/tests/ORM/Functional/Driver/SQLite/Integration/Issue482/CaseTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Integration/Issue482/CaseTest.php
@@ -15,8 +15,4 @@ use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCa
 class CaseTest extends AbstractTestCase
 {
     public const DRIVER = 'sqlite';
-
-    protected function assertExpectedSql(Select $select): void
-    {
-    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,6 +22,7 @@ $drivers = [
             database: 'spiral',
             host: '127.0.0.1',
             port: 13306,
+            charset: 'utf8mb4',
             user: 'root',
             password: 'root',
         ),

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       MYSQL_DATABASE: "spiral"
       MYSQL_ROOT_PASSWORD: "root"
       MYSQL_ROOT_HOST: "%"
+      MYSQL_CHARSET: "utf8mb4"
+      MYSQL_COLLATION: "utf8mb4_unicode_ci"
 
   cycle-postgres:
     image: postgres:15.2

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -11,20 +11,21 @@ services:
 
   cycle-mysql_latest:
     image: mysql:8.0.37
-    restart: always
-    command: --default-authentication-plugin=mysql_native_password
+    restart: on-failure
+    command: |
+      --default-authentication-plugin=mysql_native_password
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_unicode_ci
     ports:
       - "13306:3306"
     environment:
       MYSQL_DATABASE: "spiral"
       MYSQL_ROOT_PASSWORD: "root"
       MYSQL_ROOT_HOST: "%"
-      MYSQL_CHARSET: "utf8mb4"
-      MYSQL_COLLATION: "utf8mb4_unicode_ci"
 
   cycle-postgres:
     image: postgres:15.2
-    restart: always
+    restart: on-failure
     ports:
       - "15432:5432"
     environment:

--- a/tests/generate-case.php
+++ b/tests/generate-case.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Usage:
+ *  php tests/generate-case.php --case-name=Issue777
+ *  php tests/generate-case.php --case-name=Issue888 --template=Issue777
+ */
+
 declare(strict_types=1);
 
 \error_reporting(E_ALL | E_STRICT);


### PR DESCRIPTION
## 🔍 What was changed

Added key `alias` for `Select::with()` options.

> [!NOTE]
> There is PoC. Tests required

## 📝 Checklist

<!--- add/delete as needed --->

- Closes #482
- How was this tested:
  - [ ] Tested manually
  - [x] Unit tests added

## 📃 Documentation

<!--- Remove if not needed -->
