### PR TITLE
Add a test case when an exception is expected when setting a private field

### DIFF
--- a/tests/ORM/Functional/Driver/Common/Integration/Case6/CaseTest.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case6/CaseTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case6;
+
+use Cycle\ORM\Select;
+use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case6\Entity\User;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\IntegrationTestTrait;
+use Cycle\ORM\Tests\Traits\TableTrait;
+
+abstract class CaseTest extends BaseTest
+{
+    use IntegrationTestTrait;
+    use TableTrait;
+
+    public function setUp(): void
+    {
+        // Init DB
+        parent::setUp();
+
+        // Make tables
+        $this->makeTable('users', [
+            'id' => 'int,primary',
+            'login' => 'string',
+        ]);
+
+        $this->loadSchema(__DIR__ . '/schema.php');
+
+        $this->getDatabase()->table('users')->insertMultiple(
+            ['id', 'login'],
+            [
+                [1, 'foo'],
+            ],
+        );
+    }
+
+    public function testSelect(): void
+    {
+        /** @var User $model */
+        $model = (new Select($this->orm,User::class))
+            ->wherePK(1)
+            ->fetchOne();
+
+        $this->assertSame('foo', $model->getLogin());
+        $this->expectException(\Exception::class);
+        $model->login = 'new login';
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Case6/Entity/User.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case6/Entity/User.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case6\Entity;
+
+class User
+{
+    private ?int $id = null;
+    private string $login;
+
+    public function __construct(string $login)
+    {
+        $this->login = $login;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id === null ? null : (string)$this->id;
+    }
+
+    public function getLogin(): string
+    {
+        return $this->login;
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Case6/schema.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case6/schema.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\SchemaInterface as Schema;
+use Cycle\ORM\Select\Repository;
+use Cycle\ORM\Select\Source;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case6\Entity\User;
+
+return [
+    'users' => [
+        Schema::ENTITY => User::class,
+        Schema::MAPPER => Mapper::class,
+        Schema::SOURCE => Source::class,
+        Schema::REPOSITORY => Repository::class,
+        Schema::DATABASE => 'default',
+        Schema::TABLE => 'users',
+        Schema::PRIMARY_KEY => ['id'],
+        Schema::FIND_BY_KEYS => ['id'],
+        Schema::COLUMNS => [
+            'id' => 'id',
+            'login' => 'login',
+        ],
+        Schema::RELATIONS => [],
+        Schema::TYPECAST => [
+            'id' => 'int',
+            'login' => 'string',
+        ],
+    ],
+];

--- a/tests/ORM/Functional/Driver/MySQL/Integration/Case6/CaseTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Integration/Case6/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\MySQL\Integration\Case6;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case6\CaseTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/ORM/Functional/Driver/Postgres/Integration/Case6/CaseTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Integration/Case6/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Postgres\Integration\Case6;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case6\CaseTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/ORM/Functional/Driver/SQLServer/Integration/Case6/CaseTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Integration/Case6/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLServer\Integration\Case6;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case6\CaseTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/ORM/Functional/Driver/SQLite/Integration/Case6/CaseTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Integration/Case6/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLite\Integration\Case6;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case6\CaseTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+}


### PR DESCRIPTION
I found that nothing happens when I try to set a value in the private field of the Entity. I think it would be more correct to throw an exception.

Added a case in which it is expected that an exception is thrown when trying to set a value in the private field of the Entity.

- How was this tested:
  - [ ] Tested manually
  - [x] Unit tests added

