### PR TITLE
Throw Error when non-public entity property is set via proxy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,8 @@
         "cs:fix": "php-cs-fixer fix -v",
         "psalm": "psalm",
         "psalm:baseline": "psalm --set-baseline=psalm-baseline.xml",
-        "test": "phpunit --color=always"
+        "test": "phpunit --color=always",
+        "test:unit": "phpunit --exclude-group driver --colors=always",
+        "test:sqlite": "phpunit --group driver-sqlite --colors=always"
     }
 }

--- a/src/Mapper/Proxy/EntityProxyTrait.php
+++ b/src/Mapper/Proxy/EntityProxyTrait.php
@@ -57,9 +57,15 @@ trait EntityProxyTrait
     public function __set(string $name, $value): void
     {
         if (!\array_key_exists($name, $this->__cycle_orm_rel_map->getRelations())) {
-            if (\method_exists(parent::class, '__set')) {
-                parent::__set($name, $value);
+            if (!\method_exists(parent::class, '__set')) {
+                throw new \Error(\sprintf(
+                    'Cannot access non-public property %s::$%s',
+                    \get_parent_class(static::class),
+                    $name,
+                ));
             }
+
+            parent::__set($name, $value);
             return;
         }
 

--- a/tests/ORM/Functional/Driver/Common/Integration/Case6/CaseTest.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case6/CaseTest.php
@@ -44,7 +44,9 @@ abstract class CaseTest extends BaseTest
             ->fetchOne();
 
         $this->assertSame('foo', $model->getLogin());
-        $this->expectException(\Exception::class);
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Cannot access non-public property ' . User::class . '::$login');
+
         $model->login = 'new login';
     }
 }

--- a/tests/ORM/Functional/Driver/Common/Integration/Case6/CaseTest.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case6/CaseTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case6;
+
+use Cycle\ORM\Select;
+use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case6\Entity\User;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\IntegrationTestTrait;
+use Cycle\ORM\Tests\Traits\TableTrait;
+
+abstract class CaseTest extends BaseTest
+{
+    use IntegrationTestTrait;
+    use TableTrait;
+
+    public function setUp(): void
+    {
+        // Init DB
+        parent::setUp();
+
+        // Make tables
+        $this->makeTable('users', [
+            'id' => 'int,primary',
+            'login' => 'string',
+        ]);
+
+        $this->loadSchema(__DIR__ . '/schema.php');
+
+        $this->getDatabase()->table('users')->insertMultiple(
+            ['id', 'login'],
+            [
+                [1, 'foo'],
+            ],
+        );
+    }
+
+    public function testSelect(): void
+    {
+        /** @var User $model */
+        $model = (new Select($this->orm,User::class))
+            ->wherePK(1)
+            ->fetchOne();
+
+        $this->assertSame('foo', $model->getLogin());
+        $this->expectException(\Exception::class);
+        $model->login = 'new login';
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Case6/Entity/User.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case6/Entity/User.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case6\Entity;
+
+class User
+{
+    private ?int $id = null;
+    private string $login;
+
+    public function __construct(string $login)
+    {
+        $this->login = $login;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id === null ? null : (string)$this->id;
+    }
+
+    public function getLogin(): string
+    {
+        return $this->login;
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Case6/schema.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Case6/schema.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\SchemaInterface as Schema;
+use Cycle\ORM\Select\Repository;
+use Cycle\ORM\Select\Source;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case6\Entity\User;
+
+return [
+    'users' => [
+        Schema::ENTITY => User::class,
+        Schema::MAPPER => Mapper::class,
+        Schema::SOURCE => Source::class,
+        Schema::REPOSITORY => Repository::class,
+        Schema::DATABASE => 'default',
+        Schema::TABLE => 'users',
+        Schema::PRIMARY_KEY => ['id'],
+        Schema::FIND_BY_KEYS => ['id'],
+        Schema::COLUMNS => [
+            'id' => 'id',
+            'login' => 'login',
+        ],
+        Schema::RELATIONS => [],
+        Schema::TYPECAST => [
+            'id' => 'int',
+            'login' => 'string',
+        ],
+    ],
+];

--- a/tests/ORM/Functional/Driver/MySQL/Integration/Case6/CaseTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Integration/Case6/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\MySQL\Integration\Case6;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case6\CaseTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/ORM/Functional/Driver/Postgres/Integration/Case6/CaseTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Integration/Case6/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Postgres\Integration\Case6;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case6\CaseTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/ORM/Functional/Driver/SQLServer/Integration/Case6/CaseTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Integration/Case6/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLServer\Integration\Case6;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case6\CaseTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/ORM/Functional/Driver/SQLite/Integration/Case6/CaseTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Integration/Case6/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLite\Integration\Case6;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Case6\CaseTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Cycle\Database\Config;
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 ini_set('display_errors', '1');
 
 //Composer


### PR DESCRIPTION
## 🔍 What was changed

Throw Error when non-public entity property is set via proxy

## 🤔 Why?

The ORM does not write a value to a private property, nor does it report this. Now, the proxy will throw an Error when writing to a non-public property, which is similar to the standard behavior of PHP objects.

Ref: https://github.com/cycle/orm/pull/499