### PR TITLE
Removed "of object" from docBlock in "Cycle\ORM\RepositoryInterface"

### DIFF
--- a/src/FactoryInterface.php
+++ b/src/FactoryInterface.php
@@ -41,7 +41,12 @@ interface FactoryInterface extends DatabaseProviderInterface, CoreFactory
     ): LoaderInterface;
 
     /**
+     * @template TEntity
+     *
      * Create repository associated with given role.
+     *
+     * @param non-empty-string|class-string<TEntity> $role
+     * @return ($role is class-string<TEntity> ? RepositoryInterface<TEntity> : RepositoryInterface<object>)
      */
     public function repository(
         ORMInterface $orm,

--- a/src/RepositoryInterface.php
+++ b/src/RepositoryInterface.php
@@ -7,7 +7,7 @@ namespace Cycle\ORM;
 /**
  * Defines ability to locate entities based on scope parameters.
  *
- * @template TEntity of object
+ * @template TEntity
  */
 interface RepositoryInterface
 {

--- a/src/Service/Implementation/RepositoryProvider.php
+++ b/src/Service/Implementation/RepositoryProvider.php
@@ -18,7 +18,7 @@ use Cycle\ORM\Select;
  */
 final class RepositoryProvider implements RepositoryProviderInterface
 {
-    /** @var array<non-empty-string, RepositoryInterface> */
+    /** @var array<non-empty-string, RepositoryInterface<object>> */
     private array $repositories = [];
 
     public function __construct(

--- a/src/Service/RepositoryProviderInterface.php
+++ b/src/Service/RepositoryProviderInterface.php
@@ -9,9 +9,12 @@ use Cycle\ORM\RepositoryInterface;
 interface RepositoryProviderInterface
 {
     /**
+     * @template TEntity of object
+     *
      * Get repository associated with given entity role.
      *
-     * @param non-empty-string $entity
+     * @param class-string<TEntity>|non-empty-string $entity
+     * @return ($entity is class-string<TEntity> ? RepositoryInterface<TEntity> : RepositoryInterface<object>)
      */
     public function getRepository(string $entity): RepositoryInterface;
 }


### PR DESCRIPTION
<!-- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

## 🔍 What was changed

<!-- Describe what has changed in this PR.
Be clear and concise—this helps reviewers understand your changes quickly.-->
This PR removes the `of object` from the `Cycle\ORM\RepositoryInterface` class generic type.

## 🤔 Why?

<!-- Tell your future self why have you made these changes.
Remove this block if the reason was explained in the related issue. -->
This is to prevent the following psalm error from occoring when extending the `Cycle\ORM\RepositoryInterface` and then using it for the `repository` parameter in the `Cycle\Annotated\Annotation\Entity` attribute.

Error:
```
ERROR: InvalidArgument - FailedQueueJob.php:18:21 - Argument 1 of Cycle\Annotated\Annotation\Entity::__construct expects class-string<Cycle\ORM\RepositoryInterface<object>>|null, but FailedQueueJobRepository::class provided (see https://psalm.dev/004)
        repository: FailedQueueJobRepository::class
```

This PR has its origins here: https://github.com/orgs/cycle/discussions/507

## 📝 Checklist

<!--- add/delete as needed --->

- How was this tested:
  - [X] Tested manually
