### PR TITLE
Add `groupByToDeduplicate` feature

### DIFF
--- a/src/ORM.php
+++ b/src/ORM.php
@@ -176,7 +176,7 @@ final class ORM implements ORMInterface
             schema: $schema ?? $this->schema,
             commandGenerator: $this->commandGenerator,
             heap: $heap,
-            options: $options,
+            options: $options ?? $this->options,
         );
     }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -11,8 +11,15 @@ final class Options
 {
     /**
      * @readonly
+     * @note will be set to TRUE in the next major version.
      */
     public bool $ignoreUninitializedRelations = true;
+
+    /**
+     * @readonly
+     * @note will be set to TRUE in the next major version.
+     */
+    public bool $groupByToDeduplicate = false;
 
     /**
      * If TRUE, ORM will ignore relations on uninitialized Entity properties.
@@ -27,6 +34,20 @@ final class Options
     {
         $clone = clone $this;
         $clone->ignoreUninitializedRelations = $value;
+        return $clone;
+    }
+
+    /**
+     * If TRUE, ORM will use GROUP BY to deduplicate entities in Select queries in cases where
+     * `limit` and `offset` with JOINs are used.
+     *
+     * If FALSE, ORM will not use GROUP BY, which may lead wrong results in cases where
+     * `limit` and `offset` are used with JOINs.
+     */
+    public function withGroupByToDeduplicate(bool $value): static
+    {
+        $clone = clone $this;
+        $clone->groupByToDeduplicate = $value;
         return $clone;
     }
 }

--- a/src/Select.php
+++ b/src/Select.php
@@ -141,11 +141,10 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
     public function count(?string $column = null): int
     {
         if ($column === null) {
-            // @tuneyourserver solves the issue with counting on queries with joins.
-            $pk = $this->loader->getPK();
-            $column = \is_array($pk)
+            $pk = (array) $this->loader->getPK();
+            $column = \count($pk) > 1
                 ? '*'
-                : \sprintf('DISTINCT(%s)', $pk);
+                : \sprintf('DISTINCT(%s)', \reset($pk));
         }
 
         return (int) $this->__call('count', [$column]);

--- a/src/Select.php
+++ b/src/Select.php
@@ -57,15 +57,14 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
     // load related data after the query
     public const OUTER_QUERY = JoinableLoader::POSTLOAD;
 
+    protected int $limit = 0;
+    protected int $offset = 0;
     private RootLoader $loader;
     private QueryBuilder $builder;
     private MapperProviderInterface $mapperProvider;
     private Heap\HeapInterface $heap;
     private SchemaInterface $schema;
     private EntityFactoryInterface $entityFactory;
-
-    protected int $limit = 0;
-    protected int $offset = 0;
 
     /**
      * @param class-string<TEntity>|string $role
@@ -479,6 +478,18 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
     }
 
     /**
+     * @param bool $addRole If true, the role name with the key `@role` will be added to the result set.
+     * @return array<array-key, array<non-empty-string, mixed>>
+     */
+    protected function loadData(bool $addRole = true): array
+    {
+        $self = $this->addGroupByPK();
+        $node = $self->loader->createNode();
+        $self->loader->loadData($node, $addRole);
+        return $node->getResult();
+    }
+
+    /**
      * @param list<non-empty-string> $pk
      * @param list<array|int|object|string> $args
      *
@@ -516,18 +527,6 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
         }]);
 
         return $this;
-    }
-
-    /**
-     * @param bool $addRole If true, the role name with the key `@role` will be added to the result set.
-     * @return array<array-key, array<non-empty-string, mixed>>
-     */
-    protected function loadData(bool $addRole = true): array
-    {
-        $self = $this->addGroupByPK();
-        $node = $self->loader->createNode();
-        $self->loader->loadData($node, $addRole);
-        return $node->getResult();
     }
 
     /**

--- a/src/Select.php
+++ b/src/Select.php
@@ -59,6 +59,7 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
 
     protected int $limit = 0;
     protected int $offset = 0;
+    protected bool $allowGroupBy;
     private RootLoader $loader;
     private QueryBuilder $builder;
     private MapperProviderInterface $mapperProvider;
@@ -77,6 +78,7 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
         $this->schema = $orm->getSchema();
         $this->mapperProvider = $orm->getService(MapperProviderInterface::class);
         $this->entityFactory = $orm->getService(EntityFactoryInterface::class);
+        $this->allowGroupBy = $orm->getService(Options::class)->groupByToDeduplicate;
         $this->loader = new RootLoader(
             $orm->getSchema(),
             $orm->getService(SourceProviderInterface::class),
@@ -538,7 +540,7 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
      */
     private function addGroupByPK(): self
     {
-        if ($this->limit <= 1 && $this->offset === 0) {
+        if (!$this->allowGroupBy || $this->limit <= 1 && $this->offset === 0) {
             return $this;
         }
 
@@ -549,10 +551,7 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
         }
 
         $self = clone $this;
-        $pk = (array) $self->loader->getPK();
-        foreach ($pk as $key) {
-            $self->loader->getQuery()->groupBy($key);
-        }
+        $self->loader->forceGroupBy();
 
         return $self;
     }

--- a/src/Select.php
+++ b/src/Select.php
@@ -64,6 +64,9 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
     private SchemaInterface $schema;
     private EntityFactoryInterface $entityFactory;
 
+    protected int $limit = 0;
+    protected int $offset = 0;
+
     /**
      * @param class-string<TEntity>|string $role
      */
@@ -109,7 +112,7 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
      */
     public function buildQuery(): SelectQuery
     {
-        return $this->loader->buildQuery();
+        return $this->addGroupByPK()->loader->buildQuery();
     }
 
     /**
@@ -155,6 +158,7 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
      */
     public function limit(int $limit): self
     {
+        $this->limit = $limit;
         $this->loader->getQuery()->limit($limit);
 
         return $this;
@@ -165,6 +169,7 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
      */
     public function offset(int $offset): self
     {
+        $this->offset = $offset;
         $this->loader->getQuery()->offset($offset);
 
         return $this;
@@ -368,9 +373,7 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
     public function fetchOne(?array $query = null): ?object
     {
         $select = (clone $this)->where($query)->limit(1);
-        $node = $select->loader->createNode();
-        $select->loader->loadData($node, true);
-        $data = $node->getResult();
+        $data = $select->loadData();
 
         if (!isset($data[0])) {
             return null;
@@ -395,15 +398,12 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
      */
     public function getIterator(bool $findInHeap = false): Iterator
     {
-        $node = $this->loader->createNode();
-        $this->loader->loadData($node, true);
-
         return Iterator::createWithServices(
             $this->heap,
             $this->schema,
             $this->entityFactory,
             $this->loader->getTarget(),
-            $node->getResult(),
+            $this->loadData(),
             $findInHeap,
             typecast: true,
         );
@@ -412,20 +412,17 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
     /**
      * Load data tree from database and linked loaders in a form of array.
      *
-     * @return array<array-key, array<string, mixed>>
+     * @return array<array-key, array<non-empty-string, mixed>>
      */
     public function fetchData(bool $typecast = true): iterable
     {
-        $node = $this->loader->createNode();
-        $this->loader->loadData($node, false);
-
         if (!$typecast) {
-            return $node->getResult();
+            return $this->loadData(false);
         }
 
         $mapper = $this->mapperProvider->getMapper($this->loader->getTarget());
 
-        return \array_map([$mapper, 'cast'], $node->getResult());
+        return \array_map([$mapper, 'cast'], $this->loadData(false));
     }
 
     /**
@@ -450,7 +447,7 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
         if (\in_array(\strtoupper($name), ['AVG', 'MIN', 'MAX', 'SUM', 'COUNT'])) {
             // aggregations
             return $this->builder->withQuery(
-                $this->loader->buildQuery(),
+                $this->buildQuery(),
             )->__call($name, $arguments);
         }
 
@@ -519,5 +516,45 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
         }]);
 
         return $this;
+    }
+
+    /**
+     * @param bool $addRole If true, the role name with the key `@role` will be added to the result set.
+     * @return array<array-key, array<non-empty-string, mixed>>
+     */
+    protected function loadData(bool $addRole = true): array
+    {
+        $self = $this->addGroupByPK();
+        $node = $self->loader->createNode();
+        $self->loader->loadData($node, $addRole);
+        return $node->getResult();
+    }
+
+    /**
+     * Add group by for all primary keys if necessary.
+     *
+     * This is required to prevent duplicates in the result set when using LIMIT and OFFSET.
+     *
+     * @return static<TEntity> Original $this or cloned instance with group by added.
+     */
+    private function addGroupByPK(): self
+    {
+        if ($this->limit <= 1 && $this->offset === 0) {
+            return $this;
+        }
+
+        // Check if there are no joins in the query
+        if ($this->loader->getJoinedLoaders() === []) {
+            // No joins, we can safely return the original instance
+            return $this;
+        }
+
+        $self = clone $this;
+        $pk = (array) $self->loader->getPK();
+        foreach ($pk as $key) {
+            $self->loader->getQuery()->groupBy($key);
+        }
+
+        return $self;
     }
 }

--- a/src/Select/AbstractLoader.php
+++ b/src/Select/AbstractLoader.php
@@ -266,6 +266,16 @@ abstract class AbstractLoader implements LoaderInterface
     }
 
     /**
+     * Returns all loaders that are joined to the current loader.
+     *
+     * @return LoaderInterface[]
+     */
+    public function getJoinedLoaders(): array
+    {
+        return $this->join;
+    }
+
+    /**
      * Indicates that loader loads data.
      */
     abstract public function isLoaded(): bool;

--- a/src/Select/Loader/ManyToManyLoader.php
+++ b/src/Select/Loader/ManyToManyLoader.php
@@ -223,9 +223,10 @@ class ManyToManyLoader extends JoinableLoader
         bool $minify = false,
         string $prefix = '',
         bool $overwrite = false,
+        bool $addToGroup = false,
     ): SelectQuery {
         // columns are reset on earlier stage to allow pivot loader mount it's own aliases
-        return parent::mountColumns($query, $minify, $prefix, false);
+        return parent::mountColumns($query, $minify, $prefix, false, $addToGroup);
     }
 
     protected function initNode(): AbstractNode

--- a/src/Select/RootLoader.php
+++ b/src/Select/RootLoader.php
@@ -34,6 +34,7 @@ final class RootLoader extends AbstractLoader
         'scope' => true,
     ];
     private SelectQuery $query;
+    private bool $forceGroupBy = false;
 
     /**
      * @param bool $loadRelations Define loading eager relations and JTI hierarchy.
@@ -133,6 +134,18 @@ final class RootLoader extends AbstractLoader
     }
 
     /**
+     * Add selected columns to GROUP BY clause.
+     *
+     * Might be useful when deduplication is required because of JOINs or other conditions.
+     *
+     * @param bool $force When set to true, GROUP BY will be forced.
+     */
+    public function forceGroupBy(bool $force = true): void
+    {
+        $this->forceGroupBy = $force;
+    }
+
+    /**
      * Clone the underlying query.
      */
     public function __clone()
@@ -144,7 +157,7 @@ final class RootLoader extends AbstractLoader
     protected function configureQuery(SelectQuery $query): SelectQuery
     {
         return parent::configureQuery(
-            $this->mountColumns($query, true, '', true),
+            $this->mountColumns($query, true, '', true, $this->forceGroupBy),
         );
     }
 

--- a/src/Select/Traits/ColumnsTrait.php
+++ b/src/Select/Traits/ColumnsTrait.php
@@ -37,16 +37,17 @@ trait ColumnsTrait
     /**
      * Set columns into SelectQuery.
      *
-     * @param bool        $minify    Minify column names (will work in case when query parsed in
-     *                               FETCH_NUM mode).
-     * @param string      $prefix    Prefix to be added for each column name.
-     * @param bool        $overwrite When set to true existed columns will be removed.
+     * @param bool $minify Minify column names (will work in case when query parsed in FETCH_NUM mode).
+     * @param string $prefix Prefix to be added for each column name.
+     * @param bool $overwrite When set to true existed columns will be removed.
+     * @param bool $addToGroup When set to true columns will be added to GROUP BY clause.
      */
     protected function mountColumns(
         SelectQuery $query,
         bool $minify = false,
         string $prefix = '',
         bool $overwrite = false,
+        bool $addToGroup = false,
     ): SelectQuery {
         $alias = $this->getAlias();
         $columns = $overwrite ? [] : $query->getColumns();
@@ -59,6 +60,7 @@ trait ColumnsTrait
             }
 
             $columns[] = "{$alias}.{$external} AS {$prefix}{$name}";
+            $addToGroup and $query->groupBy("{$alias}.{$external}");
         }
 
         return $query->columns($columns);

--- a/src/Transaction/TupleStorage.php
+++ b/src/Transaction/TupleStorage.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Cycle\ORM\Transaction;
 
-use IteratorAggregate;
-
 /**
  * @internal
  *
- * @implements IteratorAggregate<object, Tuple>
+ * @implements \IteratorAggregate<object, Tuple>
  */
 final class TupleStorage implements \IteratorAggregate, \Countable
 {

--- a/tests/ORM/Functional/Driver/Common/Integration/CaseTemplate/TestCase.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/CaseTemplate/TestCase.php
@@ -9,7 +9,7 @@ use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
 use Cycle\ORM\Tests\Functional\Driver\Common\Integration\IntegrationTestTrait;
 use Cycle\ORM\Tests\Traits\TableTrait;
 
-abstract class CaseTest extends BaseTest
+abstract class TestCase extends BaseTest
 {
     use IntegrationTestTrait;
     use TableTrait;

--- a/tests/ORM/Functional/Driver/Common/Integration/Issue528/AbstractTestCase.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Issue528/AbstractTestCase.php
@@ -31,6 +31,19 @@ abstract class AbstractTestCase extends BaseTest
         $this->assertCount(2, $data);
     }
 
+    public function testLoadWherePagination2(): void
+    {
+        $select = (new Select($this->orm, Country::class))
+            ->load('translations')
+            ->load('translations.locale')
+            ->where('translations.locale.id', 1);
+        /** @var Paginator $paginator */
+        $paginator = (new Paginator(2))->paginate($select);
+        $data = $select->fetchData();
+        $this->assertSame(10, $paginator->count());
+        $this->assertCount(2, $data);
+    }
+
     public function testWithLeft(): void
     {
         $select = (new Select($this->orm, Country::class))

--- a/tests/ORM/Functional/Driver/Common/Integration/Issue528/AbstractTestCase.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Issue528/AbstractTestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue528;
 
 use Cycle\ORM\Select;
+use Cycle\ORM\Select\JoinableLoader;
 use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
 use Cycle\ORM\Tests\Functional\Driver\Common\Integration\IntegrationTestTrait;
 use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue528\Entity\Country;
@@ -21,6 +22,36 @@ abstract class AbstractTestCase extends BaseTest
         $select = (new Select($this->orm, Country::class))
             ->load('translations')
             ->where('translations.locale_id', 1);
+        /** @var Paginator $paginator */
+        $paginator = (new Paginator(2))->paginate($select);
+        $data = $select->fetchData();
+        $this->assertSame(10, $paginator->count());
+        $this->assertCount(2, $data);
+    }
+
+    public function testWithLeft(): void
+    {
+        $select = (new Select($this->orm, Country::class))
+            ->with('translations', [
+                'as' => 'trans',
+                'alias' => 'trans',
+                'method' => JoinableLoader::LEFT_JOIN,
+            ]);
+        /** @var Paginator $paginator */
+        $paginator = (new Paginator(2))->paginate($select);
+        $data = $select->fetchData();
+        $this->assertSame(10, $paginator->count());
+        $this->assertCount(2, $data);
+    }
+
+    public function testWithInner(): void
+    {
+        $select = (new Select($this->orm, Country::class))
+            ->with('translations', [
+                'as' => 'trans',
+                'alias' => 'trans',
+                'method' => JoinableLoader::JOIN,
+            ]);
         /** @var Paginator $paginator */
         $paginator = (new Paginator(2))->paginate($select);
         $data = $select->fetchData();

--- a/tests/ORM/Functional/Driver/Common/Integration/Issue528/AbstractTestCase.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Issue528/AbstractTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue528;
 
+use Cycle\ORM\Options;
 use Cycle\ORM\Select;
 use Cycle\ORM\Select\JoinableLoader;
 use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
@@ -63,6 +64,9 @@ abstract class AbstractTestCase extends BaseTest
     {
         // Init DB
         parent::setUp();
+        $this->orm = $this->orm->with(
+            options: (new Options())->withGroupByToDeduplicate(true),
+        );
         $this->makeTables();
         $this->fillData();
 

--- a/tests/ORM/Functional/Driver/Common/Integration/Issue528/AbstractTestCase.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Issue528/AbstractTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue528;
 
+use Cycle\ORM\Exception\LoaderException;
 use Cycle\ORM\Options;
 use Cycle\ORM\Select;
 use Cycle\ORM\Select\JoinableLoader;
@@ -45,6 +46,22 @@ abstract class AbstractTestCase extends BaseTest
         $this->assertCount(2, $data);
     }
 
+    public function testWithLeftAndWhere(): void
+    {
+        $select = (new Select($this->orm, Country::class))
+            ->with('translations', [
+                'as' => 'trans',
+                'alias' => 'trans',
+                'method' => JoinableLoader::LEFT_JOIN,
+            ])
+            ->where('translations.locale_id', 1);
+        /** @var Paginator $paginator */
+        $paginator = (new Paginator(2))->paginate($select);
+        $data = $select->fetchData();
+        $this->assertSame(10, $paginator->count());
+        $this->assertCount(2, $data);
+    }
+
     public function testWithInner(): void
     {
         $select = (new Select($this->orm, Country::class))
@@ -58,6 +75,54 @@ abstract class AbstractTestCase extends BaseTest
         $data = $select->fetchData();
         $this->assertSame(10, $paginator->count());
         $this->assertCount(2, $data);
+    }
+
+    public function testWithInnerAndWhere(): void
+    {
+        $select = (new Select($this->orm, Country::class))
+            ->with('translations', [
+                'as' => 'trans',
+                'alias' => 'trans',
+                'method' => JoinableLoader::JOIN,
+            ])
+            ->where('translations.locale_id', 1);
+        /** @var Paginator $paginator */
+        $paginator = (new Paginator(2))->paginate($select);
+        $data = $select->fetchData();
+        $this->assertSame(10, $paginator->count());
+        $this->assertCount(2, $data);
+    }
+
+    public function testWithAndLoad(): void
+    {
+        $select = (new Select($this->orm, Country::class))
+            ->with('translations', [
+                'as' => 'with_trans',
+                'method' => JoinableLoader::LEFT_JOIN,
+            ])
+            ->load('translations')
+            ->where('translations.locale_id', 1);
+        /** @var Paginator $paginator */
+        $paginator = (new Paginator(2))->paginate($select);
+        $data = $select->fetchData();
+        $this->assertSame(10, $paginator->count());
+        $this->assertCount(2, $data);
+    }
+
+    public function testWithAndLoadUsing(): void
+    {
+        self::expectException(LoaderException::class);
+        self::expectExceptionMessage('Unable to load data using join with limit on parent query');
+
+        $select = (new Select($this->orm, Country::class))
+            ->with('translations', [
+                'as' => 'with_trans',
+                'method' => JoinableLoader::LEFT_JOIN,
+            ])
+            ->load('translations', ['using' => 'with_trans'])
+            ->where('translations.locale_id', 1);
+        (new Paginator(2))->paginate($select);
+        $select->fetchData();
     }
 
     public function setUp(): void

--- a/tests/ORM/Functional/Driver/Common/Integration/Issue528/AbstractTestCase.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Issue528/AbstractTestCase.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue528;
+
+use Cycle\ORM\Select;
+use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\IntegrationTestTrait;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue528\Entity\Country;
+use Cycle\ORM\Tests\Traits\TableTrait;
+use Spiral\Pagination\Paginator;
+
+abstract class AbstractTestCase extends BaseTest
+{
+    use IntegrationTestTrait;
+    use TableTrait;
+
+    public function testLoadWherePagination(): void
+    {
+        $select = (new Select($this->orm, Country::class))
+            ->load('translations')
+            ->where('translations.locale_id', 1);
+        /** @var Paginator $paginator */
+        $paginator = (new Paginator(2))->paginate($select);
+        $data = $select->fetchData();
+        $this->assertSame(10, $paginator->count());
+        $this->assertCount(2, $data);
+    }
+
+    public function setUp(): void
+    {
+        // Init DB
+        parent::setUp();
+        $this->makeTables();
+        $this->fillData();
+
+        $this->loadSchema(__DIR__ . '/schema.php');
+    }
+
+    private function makeTables(): void
+    {
+        // Make tables
+        $this->makeTable('country', [
+            'id' => 'primary', // autoincrement
+            'name' => 'string',
+        ]);
+
+        $this->makeTable('locale', [
+            'id' => 'primary',
+            'code' => 'string',
+        ]);
+
+        $this->makeTable('translation', [
+            'id' => 'primary',
+            'title' => 'string',
+            'country_id' => 'int',
+            'locale_id' => 'int',
+        ]);
+        $this->makeFK('translation', 'country_id', 'country', 'id', 'NO ACTION', 'NO ACTION');
+        $this->makeFK('translation', 'locale_id', 'locale', 'id', 'NO ACTION', 'NO ACTION');
+    }
+
+    private function fillData(): void
+    {
+        $this->getDatabase()->table('translation')->delete()->run();
+        $this->getDatabase()->table('country')->delete()->run();
+        $this->getDatabase()->table('locale')->delete()->run();
+
+        $locales = [
+            ['en'],
+            ['ru'],
+        ];
+        $this->getDatabase()->table('locale')->insertMultiple(
+            ['code'],
+            $locales,
+        );
+        $countries = [
+            ['Russia'],
+            ['USA'],
+            ['China'],
+            ['Kazakhstan'],
+            ['Japan'],
+            ['Germany'],
+            ['France'],
+            ['Italy'],
+            ['Spain'],
+            ['India'],
+        ];
+        $this->getDatabase()->table('country')->insertMultiple(
+            ['name'],
+            $countries,
+        );
+
+        $values = [];
+        foreach ($countries as $i => $country) {
+            // Duplicate translations for each locale.
+            // There are 2 same translations for each country.
+            for ($k = 0; $k < 2; $k++) {
+                foreach ($locales as $j => $locale) {
+                    $values[] = [$i + 1, $j + 1, "{$country[0]}-{$locale[0]}"];
+                }
+            }
+        }
+        $this->getDatabase()->table('translation')->insertMultiple(
+            ['country_id', 'locale_id', 'title'],
+            $values,
+        );
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Issue528/Entity/Country.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Issue528/Entity/Country.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue528\Entity;
+
+class Country
+{
+    public ?int $id = null;
+    public string $name;
+
+    /** @var iterable<Translation> */
+    public iterable $translations = [];
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Issue528/Entity/Locale.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Issue528/Entity/Locale.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue528\Entity;
+
+class Locale
+{
+    public ?int $id = null;
+    public string $code;
+
+    /** @var iterable<Translation> */
+    public iterable $translations = [];
+
+    public function __construct(string $code)
+    {
+        $this->code = $code;
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Issue528/Entity/Translation.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Issue528/Entity/Translation.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue528\Entity;
+
+class Translation
+{
+    public ?int $id = null;
+    public Country $country;
+    public Locale $locale;
+    public string $title;
+
+    public function __construct(Country $country, Locale $locale, string $title)
+    {
+        $this->country = $country;
+        $this->locale = $locale;
+        $this->title = $title;
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Integration/Issue528/schema.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Issue528/schema.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\Relation;
+use Cycle\ORM\SchemaInterface as Schema;
+use Cycle\ORM\Select\Repository;
+use Cycle\ORM\Select\Source;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue528\Entity\Translation;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue528\Entity\Country;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue528\Entity\Locale;
+
+return [
+    'country' => [
+        Schema::ENTITY => Country::class,
+        Schema::SOURCE => Source::class,
+        Schema::DATABASE => 'default',
+        Schema::MAPPER => Mapper::class,
+        Schema::TABLE => 'country',
+        Schema::PRIMARY_KEY => ['id'],
+        Schema::FIND_BY_KEYS => ['id'],
+        Schema::COLUMNS => [
+            'id' => 'id',
+            'name' => 'name',
+        ],
+        Schema::RELATIONS => [
+            'translations' => [
+                Relation::TYPE => Relation::HAS_MANY,
+                Relation::TARGET => 'translation',
+                Relation::COLLECTION_TYPE => 'array',
+                Relation::LOAD => Relation::LOAD_PROMISE,
+                Relation::SCHEMA => [
+                    Relation::CASCADE => true,
+                    Relation::NULLABLE => false,
+                    Relation::WHERE => [],
+                    Relation::ORDER_BY => [],
+                    Relation::INNER_KEY => ['id'],
+                    Relation::OUTER_KEY => 'country_id',
+                ],
+            ],
+        ],
+        Schema::TYPECAST => [
+            'id' => 'int',
+            'name' => 'string',
+            'code' => 'string',
+            'isFriendly' => 'bool',
+        ],
+        Schema::SCHEMA => [],
+    ],
+    'translation' => [
+        Schema::ENTITY => Translation::class,
+        Schema::SOURCE => Source::class,
+        Schema::DATABASE => 'default',
+        Schema::TABLE => 'translation',
+        Schema::PRIMARY_KEY => ['id'],
+        Schema::FIND_BY_KEYS => ['id'],
+        Schema::COLUMNS => [
+            'id' => 'id',
+            'country_id' => 'country_id',
+            'locale_id' => 'locale_id',
+            'title' => 'title',
+        ],
+        Schema::RELATIONS => [
+            'country' => [
+                Relation::TYPE => Relation::BELONGS_TO,
+                Relation::TARGET => 'country',
+                Relation::LOAD => Relation::LOAD_EAGER,
+                Relation::SCHEMA => [
+                    Relation::CASCADE => true,
+                    Relation::NULLABLE => false,
+                    Relation::INNER_KEY => 'country_id',
+                    Relation::OUTER_KEY => ['id'],
+                ],
+            ],
+            'locale' => [
+                Relation::TYPE => Relation::BELONGS_TO,
+                Relation::TARGET => 'locale',
+                Relation::LOAD => Relation::LOAD_PROMISE,
+                Relation::SCHEMA => [
+                    Relation::CASCADE => true,
+                    Relation::NULLABLE => false,
+                    Relation::INNER_KEY => 'locale_id',
+                    Relation::OUTER_KEY => ['id'],
+                ],
+            ],
+        ],
+        Schema::TYPECAST => [
+            'id' => 'int',
+            'country_id' => 'int',
+            'locale_id' => 'int',
+            'title' => 'string',
+        ],
+        Schema::SCHEMA => [],
+    ],
+    'locale' => [
+        Schema::ENTITY => Locale::class,
+        Schema::MAPPER => Mapper::class,
+        Schema::SOURCE => Source::class,
+        Schema::REPOSITORY => Repository::class,
+        Schema::DATABASE => 'default',
+        Schema::TABLE => 'locale',
+        Schema::PRIMARY_KEY => ['id'],
+        Schema::FIND_BY_KEYS => ['id'],
+        Schema::COLUMNS => [
+            'id' => 'id',
+            'code' => 'code',
+        ],
+        Schema::RELATIONS => [
+            'translations' => [
+                Relation::TYPE => Relation::HAS_MANY,
+                Relation::TARGET => 'translation',
+                Relation::COLLECTION_TYPE => 'array',
+                Relation::LOAD => Relation::LOAD_PROMISE,
+                Relation::SCHEMA => [
+                    Relation::CASCADE => true,
+                    Relation::NULLABLE => false,
+                    Relation::WHERE => [],
+                    Relation::ORDER_BY => [],
+                    Relation::INNER_KEY => ['id'],
+                    Relation::OUTER_KEY => 'locale_id',
+                ],
+            ],
+        ],
+        Schema::SCOPE => null,
+        Schema::TYPECAST => [
+            'id' => 'int',
+            'code' => 'string',
+        ],
+        Schema::SCHEMA => [],
+    ],
+];

--- a/tests/ORM/Functional/Driver/MySQL/Integration/CaseTemplate/TestCase.php
+++ b/tests/ORM/Functional/Driver/MySQL/Integration/CaseTemplate/TestCase.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Cycle\ORM\Tests\Functional\Driver\MySQL\Integration\CaseTemplate;
 
 // phpcs:ignore
-use Cycle\ORM\Tests\Functional\Driver\Common\Integration\CaseTemplate\CaseTest as CommonClass;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\CaseTemplate\TestCase as CommonClass;
 
 /**
  * @group driver
  * @group driver-mysql
  */
-class CaseTest extends CommonClass
+class TestCase extends CommonClass
 {
     public const DRIVER = 'mysql';
 }

--- a/tests/ORM/Functional/Driver/MySQL/Integration/Issue482/AbstractTestCase.php
+++ b/tests/ORM/Functional/Driver/MySQL/Integration/Issue482/AbstractTestCase.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\MySQL\Integration\Issue482;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCase as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class AbstractTestCase extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/ORM/Functional/Driver/MySQL/Integration/Issue528/CaseTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Integration/Issue528/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\MySQL\Integration\Issue528;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue528\AbstractTestCase as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/ORM/Functional/Driver/Postgres/Integration/CaseTemplate/TestCase.php
+++ b/tests/ORM/Functional/Driver/Postgres/Integration/CaseTemplate/TestCase.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Cycle\ORM\Tests\Functional\Driver\Postgres\Integration\CaseTemplate;
 
 // phpcs:ignore
-use Cycle\ORM\Tests\Functional\Driver\Common\Integration\CaseTemplate\CaseTest as CommonClass;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\CaseTemplate\TestCase as CommonClass;
 
 /**
  * @group driver
  * @group driver-postgres
  */
-class CaseTest extends CommonClass
+class TestCase extends CommonClass
 {
     public const DRIVER = 'postgres';
 }

--- a/tests/ORM/Functional/Driver/Postgres/Integration/Issue482/AbstractTestCase.php
+++ b/tests/ORM/Functional/Driver/Postgres/Integration/Issue482/AbstractTestCase.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Postgres\Integration\Issue482;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCase as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class AbstractTestCase extends CommonClass
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/ORM/Functional/Driver/Postgres/Integration/Issue528/CaseTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Integration/Issue528/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Postgres\Integration\Issue528;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue528\AbstractTestCase as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/ORM/Functional/Driver/SQLServer/Integration/CaseTemplate/TestCase.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Integration/CaseTemplate/TestCase.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Cycle\ORM\Tests\Functional\Driver\SQLServer\Integration\CaseTemplate;
 
 // phpcs:ignore
-use Cycle\ORM\Tests\Functional\Driver\Common\Integration\CaseTemplate\CaseTest as CommonClass;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\CaseTemplate\TestCase as CommonClass;
 
 /**
  * @group driver
  * @group driver-sqlserver
  */
-class CaseTest extends CommonClass
+class TestCase extends CommonClass
 {
     public const DRIVER = 'sqlserver';
 }

--- a/tests/ORM/Functional/Driver/SQLServer/Integration/Issue482/AbstractTestCase.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Integration/Issue482/AbstractTestCase.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLServer\Integration\Issue482;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCase as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class AbstractTestCase extends CommonClass
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/ORM/Functional/Driver/SQLServer/Integration/Issue528/CaseTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Integration/Issue528/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLServer\Integration\Issue528;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue528\AbstractTestCase as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/ORM/Functional/Driver/SQLite/Integration/CaseTemplate/TestCase.php
+++ b/tests/ORM/Functional/Driver/SQLite/Integration/CaseTemplate/TestCase.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Cycle\ORM\Tests\Functional\Driver\SQLite\Integration\CaseTemplate;
 
 // phpcs:ignore
-use Cycle\ORM\Tests\Functional\Driver\Common\Integration\CaseTemplate\CaseTest as CommonClass;
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\CaseTemplate\TestCase as CommonClass;
 
 /**
  * @group driver
  * @group driver-sqlite
  */
-class CaseTest extends CommonClass
+class TestCase extends CommonClass
 {
     public const DRIVER = 'sqlite';
 }

--- a/tests/ORM/Functional/Driver/SQLite/Integration/Issue482/AbstractTestCase.php
+++ b/tests/ORM/Functional/Driver/SQLite/Integration/Issue482/AbstractTestCase.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLite\Integration\Issue482;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue482\AbstractTestCase as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class AbstractTestCase extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+}

--- a/tests/ORM/Functional/Driver/SQLite/Integration/Issue528/CaseTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Integration/Issue528/CaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLite\Integration\Issue528;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue528\AbstractTestCase as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class CaseTest extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+}

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   cycle-sqlserver:
     image: mcr.microsoft.com/mssql/server:2019-latest

--- a/tests/generate-case.php
+++ b/tests/generate-case.php
@@ -8,7 +8,7 @@
 
 declare(strict_types=1);
 
-\error_reporting(E_ALL | E_STRICT);
+\error_reporting(E_ALL);
 \ini_set('display_errors', '1');
 
 //Composer

--- a/tests/generate.php
+++ b/tests/generate.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Cycle\ORM\Tests\Util\DontGenerateAttribute;
 use Spiral\Tokenizer;
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 ini_set('display_errors', '1');
 
 //Composer


### PR DESCRIPTION
## What was changed

- added a new Options flag `groupByToDeduplicate`
- when `groupByToDeduplicate` is true, a GroupBy with main columns will be added when limit, offset, and joins are set

## 📝 Checklist

<!--- add/delete as needed --->

- Closes #527
- How was this tested:
  - [ ] Tested manually
  - [x] Unit tests added

