### PR TITLE
feat: Add the Relations Bulk Loader

### DIFF
--- a/src/Parser/AbstractNode.php
+++ b/src/Parser/AbstractNode.php
@@ -62,7 +62,7 @@ abstract class AbstractNode
      *
      * @internal
      */
-    protected ?MultiKeyCollection $indexedData = null;
+    protected MultiKeyCollection $indexedData;
 
     /**
      * @param string[] $columns List of columns node must fetch from the row.
@@ -257,7 +257,7 @@ abstract class AbstractNode
     {
         $this->parent = null;
         $this->nodes = [];
-        $this->indexedData = null;
+        unset($this->indexedData);
         $this->duplicates = [];
     }
 

--- a/src/Parser/SingularNode.php
+++ b/src/Parser/SingularNode.php
@@ -61,7 +61,7 @@ final class SingularNode extends AbstractNode
         $this->parent->mount(
             $this->container,
             $this->indexName,
-            ['@role' => $role, ...$this->intersectData($this->innerKeys, $data)],
+            ['@role' => $role] + $this->intersectData($this->innerKeys, $data),
             $data,
         );
     }

--- a/src/Parser/StaticNode.php
+++ b/src/Parser/StaticNode.php
@@ -31,12 +31,12 @@ final class StaticNode extends OutputNode
             }
         }
 
-        // // Let's force placeholders for every sub loaded
-        // foreach ($this->nodes as $name => $node) {
-        //     if ($node instanceof ParentMergeNode) {
-        //         continue;
-        //     }
-        //     $data[$name] = $node instanceof ArrayNode ? [] : null;
-        // }
+        // Let's force placeholders for every sub loaded
+        foreach ($this->nodes as $name => $node) {
+            if ($node instanceof ParentMergeNode) {
+                continue;
+            }
+            $data[$name] = $node instanceof ArrayNode ? [] : null;
+        }
     }
 }

--- a/src/Parser/StaticNode.php
+++ b/src/Parser/StaticNode.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Parser;
+
+/**
+ * This node is used when entity data is already loaded.
+ *
+ * @internal
+ */
+final class StaticNode extends OutputNode
+{
+    /**
+     * @param non-empty-string[] $columns
+     * @param non-empty-string[] $primaryKeys
+     */
+    public function __construct(array $columns, array $primaryKeys)
+    {
+        parent::__construct($columns, null);
+        $this->setDuplicateCriteria($primaryKeys);
+    }
+
+    public function push(array &$data): void
+    {
+        parent::push($data);
+        foreach ($this->indexedData->getIndexes() as $index) {
+            try {
+                $this->indexedData->addItem($index, $data);
+            } catch (\Throwable) {
+            }
+        }
+
+        // // Let's force placeholders for every sub loaded
+        // foreach ($this->nodes as $name => $node) {
+        //     if ($node instanceof ParentMergeNode) {
+        //         continue;
+        //     }
+        //     $data[$name] = $node instanceof ArrayNode ? [] : null;
+        // }
+    }
+}

--- a/src/Relation/BulkLoader.php
+++ b/src/Relation/BulkLoader.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Cycle\ORM\Relation;
 
-use Cycle\ORM\Heap\HeapInterface;
 use Cycle\ORM\Heap\Node;
 use Cycle\ORM\ORMInterface;
 use Cycle\ORM\Reference\ReferenceInterface;
@@ -75,8 +74,11 @@ final class BulkLoader implements BulkLoaderInterface, RelationLoaderInterface
         $factory = $this->orm->getService(EntityFactoryInterface::class);
 
         foreach ($this->entities as $entity) {
-            $data = $mapper->uncast($mapper->fetchFields($entity));
-            $this->indexEntity($heap, $pk, $data, $entity);
+            $n = $heap->get($entity) ?? throw new \LogicException("Entity node not found in the heap.");
+            // Use Node data to load relations instead of actual entity data
+            // to avoid inconsistent state in the Heap
+            $data = $n->getData();
+            $this->indexEntity($n, $pk, $data, $entity);
             $node->push($data);
             unset($data);
         }
@@ -113,7 +115,7 @@ final class BulkLoader implements BulkLoaderInterface, RelationLoaderInterface
      * @param non-empty-array<non-empty-string> $keys
      * @param non-empty-array<non-empty-string> $data
      */
-    public function indexEntity(HeapInterface $heap, array $keys, array $data, object $entity): void
+    public function indexEntity(Node $node, array $keys, array $data, object $entity): void
     {
         $pool = &$this->index;
         foreach ($keys as $k) {
@@ -125,10 +127,7 @@ final class BulkLoader implements BulkLoaderInterface, RelationLoaderInterface
         }
 
 
-        $pool = [
-            $entity,
-            $heap->get($entity) ?? throw new \LogicException("Entity node not found in the heap."),
-        ];
+        $pool = [$entity, $node];
     }
 
     /**

--- a/src/Relation/BulkLoader.php
+++ b/src/Relation/BulkLoader.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Relation;
+
+use Cycle\ORM\Heap\HeapInterface;
+use Cycle\ORM\Heap\Node;
+use Cycle\ORM\ORMInterface;
+use Cycle\ORM\Reference\ReferenceInterface;
+use Cycle\ORM\SchemaInterface;
+use Cycle\ORM\Select\UpdateLoader;
+use Cycle\ORM\Service\EntityFactoryInterface;
+use Cycle\ORM\Service\SourceProviderInterface;
+
+/**
+ * @internal
+ */
+final class BulkLoader implements BulkLoaderInterface, RelationLoaderInterface
+{
+    /** @var list<object> */
+    private array $entities = [];
+
+    private UpdateLoader $loader;
+    private array $index = [];
+
+    public function __construct(
+        private ORMInterface $orm,
+    ) {}
+
+    public function collect(object ...$entities): RelationLoaderInterface
+    {
+        if ($entities === []) {
+            return $this;
+        }
+
+        $entities = \array_values($entities);
+
+        // Validate entity roles
+        $role = $this->orm->resolveRole($entities[0]);
+        foreach ($entities as $entity) {
+            // todo STI/JTI support
+            if ($this->orm->resolveRole($entity) !== $role) {
+                throw new \InvalidArgumentException('All entities must belong to the same role.');
+            }
+        }
+
+        $clone = clone $this;
+        $clone->entities = \array_merge($this->entities, $entities);
+        $clone->loader = new UpdateLoader(
+            $this->orm->getSchema(),
+            $this->orm->getService(SourceProviderInterface::class),
+            $this->orm->getFactory(),
+            $role,
+        );
+
+        return $clone;
+    }
+
+    public function load(string $relation, array $options = []): static
+    {
+        $this->loader->loadRelation($relation, $options, load: true);
+        return $this;
+    }
+
+    public function run(): void
+    {
+        $role = $this->loader->getTarget();
+        $mapper = $this->orm->getMapper($role);
+        $node = $this->loader->createNode();
+        $pk = (array) $this->orm->getSchema()->define($role, SchemaInterface::PRIMARY_KEY);
+        $relMap = $this->orm->getRelationMap($role);
+        $relations = $relMap->getRelations();
+        $heap = $this->orm->getHeap();
+        $factory = $this->orm->getService(EntityFactoryInterface::class);
+
+        foreach ($this->entities as $entity) {
+            $data = $mapper->uncast($mapper->fetchFields($entity));
+            $this->indexEntity($heap, $pk, $data, $entity);
+            $node->push($data);
+            unset($data);
+        }
+
+        $this->loader->loadData($node, true);
+        $result = $node->getResult();
+
+        // Fill entities with loaded relations
+        foreach ($result as $data) {
+            [$entity, $node] = $this->getEntity($pk, $data);
+            $fetched = $mapper->fetchRelations($entity);
+
+            // Get not resolved (references) or not set relations
+            $overwrite = [];
+            foreach ($relations as $name => $_) {
+                if (\array_key_exists($name, $data) && ($fetched[$name] ?? null) instanceof ReferenceInterface) {
+                    $overwrite[$name] = $data[$name];
+                }
+            }
+
+            if ($overwrite === []) {
+                continue;
+            }
+
+            $mapper->hydrate($entity, $relMap->init($factory, $node, $mapper->cast($overwrite)));
+        }
+
+        $this->index = [];
+    }
+
+    /**
+     * Index entity by provided keys and data.
+     *
+     * @param non-empty-array<non-empty-string> $keys
+     * @param non-empty-array<non-empty-string> $data
+     */
+    public function indexEntity(HeapInterface $heap, array $keys, array $data, object $entity): void
+    {
+        $pool = &$this->index;
+        foreach ($keys as $k) {
+            $keyValue = $data[$k] ?? throw new \LogicException("Bulk loader cannot get the value for the key `$k`.");
+            \is_scalar($keyValue) or throw new \InvalidArgumentException("Invalid value on the key `$k`.");
+
+            \array_key_exists($keyValue, $pool) or $pool[$keyValue] = [];
+            $pool = &$pool[$keyValue];
+        }
+
+
+        $pool = [
+            $entity,
+            $heap->get($entity) ?? throw new \LogicException("Entity node not found in the heap."),
+        ];
+    }
+
+    /**
+     * Fetch indexed entity by provided keys and data.
+     *
+     * @param non-empty-array<non-empty-string> $pk
+     * @param non-empty-array<non-empty-string> $data
+     *
+     * @return array{object, Node} The indexed entity and its node
+     */
+    private function getEntity(array $pk, array $data): array
+    {
+        $result = $this->index;
+        foreach ($pk as $k) {
+            $result = $result[$data[$k]] ?? throw new \LogicException('Cannot find indexed entity.');
+        }
+
+        return $result;
+    }
+}

--- a/src/Relation/BulkLoader.php
+++ b/src/Relation/BulkLoader.php
@@ -29,10 +29,7 @@ final class BulkLoader implements BulkLoaderInterface, RelationLoaderInterface
 
     public function collect(object ...$entities): RelationLoaderInterface
     {
-        if ($entities === []) {
-            return $this;
-        }
-
+        $entities === [] and throw new \InvalidArgumentException('At least one entity must be provided.');
         $entities = \array_values($entities);
 
         // Validate entity roles

--- a/src/Relation/BulkLoaderInterface.php
+++ b/src/Relation/BulkLoaderInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Relation;
+
+/**
+ * Bulk relation loader allows to collect a set of entities and load their relations in bulk.
+ */
+interface BulkLoaderInterface
+{
+    /**
+     * Collect entities for bulk relation loading.
+     *
+     * @param object ...$entities Entities to collect
+     * @psalm-immutable
+     */
+    public function collect(object ...$entities): RelationLoaderInterface;
+}

--- a/src/Relation/RelationLoaderInterface.php
+++ b/src/Relation/RelationLoaderInterface.php
@@ -12,6 +12,10 @@ use Cycle\ORM\Select;
  * Allows to load relations in bulk for a set of collected entities.
  *
  * @note Don't implement this interface directly. The signature might change in the future.
+ *
+ * Important behavior:
+ * - Relations are loaded using the entity state from the database (heap node data), not runtime changes
+ * - Already loaded relations (non-references) will not be overwritten
  */
 interface RelationLoaderInterface
 {
@@ -27,6 +31,9 @@ interface RelationLoaderInterface
 
     /**
      * Execute relation loading for all collected entities.
+     *
+     * Only unresolved relations (lazy references) will be loaded.
+     * Relations use database state for loading, ignoring runtime changes to foreign keys.
      */
     public function run(): void;
 }

--- a/src/Relation/RelationLoaderInterface.php
+++ b/src/Relation/RelationLoaderInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Relation;
+
+use Cycle\ORM\Select;
+
+/**
+ * Relations loader
+ *
+ * Allows to load relations in bulk for a set of collected entities.
+ *
+ * @note Don't implement this interface directly. The signature might change in the future.
+ */
+interface RelationLoaderInterface
+{
+    /**
+     * Define relation to be loaded.
+     *
+     * @param non-empty-string $relation Relation name
+     * @param array $options Relation loading options
+     *
+     * @see Select::load() for available options\
+     */
+    public function load(string $relation, array $options = []): static;
+
+    /**
+     * Execute relation loading for all collected entities.
+     */
+    public function run(): void;
+}

--- a/src/Select/AbstractLoader.php
+++ b/src/Select/AbstractLoader.php
@@ -17,6 +17,7 @@ use Cycle\ORM\Select\Loader\ParentLoader;
 use Cycle\ORM\Select\Loader\SubclassLoader;
 use Cycle\ORM\Select\Traits\AliasTrait;
 use Cycle\ORM\Select\Traits\ChainTrait;
+use Iterator;
 use JetBrains\PhpStorm\Deprecated;
 
 /**
@@ -402,6 +403,8 @@ abstract class AbstractLoader implements LoaderInterface
 
     /**
      * Returns list of relations to be automatically joined with parent object.
+     *
+     * @return \Generator<int, LoaderInterface|non-empty-string>
      */
     protected function getEagerLoaders(?string $role = null): \Generator
     {
@@ -410,7 +413,7 @@ abstract class AbstractLoader implements LoaderInterface
         if ($parentLoader !== null) {
             yield $parentLoader;
         }
-        yield from $this->generateSublassLoaders();
+        yield from $this->generateSubclassLoaders();
         yield from $this->generateEagerRelationLoaders($role);
     }
 
@@ -422,17 +425,23 @@ abstract class AbstractLoader implements LoaderInterface
             : $this->factory->loader($this->ormSchema, $this->sourceProvider, $role, FactoryInterface::PARENT_LOADER);
     }
 
-    protected function generateSublassLoaders(): iterable
+    /**
+     * @return iterable<LoaderInterface>
+     */
+    protected function generateSubclassLoaders(): iterable
     {
         if ($this->children !== []) {
-            foreach ($this->children as $subRole => $children) {
+            foreach ($this->children as $subRole => $_) {
                 yield $this->factory
                     ->loader($this->ormSchema, $this->sourceProvider, $subRole, FactoryInterface::CHILD_LOADER);
             }
         }
     }
 
-    protected function generateEagerRelationLoaders(string $target): \Generator
+    /**
+     * @return iterable<non-empty-string>
+     */
+    protected function generateEagerRelationLoaders(string $target): iterable
     {
         $relations = $this->ormSchema->define($target, SchemaInterface::RELATIONS) ?? [];
         foreach ($relations as $relation => $schema) {

--- a/src/Select/AbstractLoader.php
+++ b/src/Select/AbstractLoader.php
@@ -17,7 +17,6 @@ use Cycle\ORM\Select\Loader\ParentLoader;
 use Cycle\ORM\Select\Loader\SubclassLoader;
 use Cycle\ORM\Select\Traits\AliasTrait;
 use Cycle\ORM\Select\Traits\ChainTrait;
-use Iterator;
 use JetBrains\PhpStorm\Deprecated;
 
 /**

--- a/src/Select/JoinableLoader.php
+++ b/src/Select/JoinableLoader.php
@@ -169,6 +169,11 @@ abstract class JoinableLoader extends AbstractLoader implements JoinableInterfac
      */
     public function isJoined(): bool
     {
+        /** It's impossible to join with {@see UpdateLoader} because it doesn't produce any SQL */
+        if ($this->parent instanceof UpdateLoader) {
+            return false;
+        }
+
         if (!empty($this->options['using'])) {
             return true;
         }

--- a/src/Select/Loader/ParentLoader.php
+++ b/src/Select/Loader/ParentLoader.php
@@ -63,7 +63,7 @@ class ParentLoader extends JoinableLoader
         return parent::configureQuery($query);
     }
 
-    protected function generateSublassLoaders(): iterable
+    protected function generateSubclassLoaders(): iterable
     {
         return [];
     }

--- a/src/Select/Traits/ColumnsTrait.php
+++ b/src/Select/Traits/ColumnsTrait.php
@@ -68,6 +68,8 @@ trait ColumnsTrait
 
     /**
      * Return original column names.
+     *
+     * @return non-empty-string[]
      */
     protected function columnNames(): array
     {

--- a/src/Select/UpdateLoader.php
+++ b/src/Select/UpdateLoader.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Select;
+
+use Cycle\ORM\FactoryInterface;
+use Cycle\ORM\Parser\AbstractNode;
+use Cycle\ORM\Parser\StaticNode;
+use Cycle\ORM\Service\SourceProviderInterface;
+use Cycle\ORM\SchemaInterface;
+use Cycle\ORM\Select\Traits\ColumnsTrait;
+use Cycle\ORM\Select\Traits\ScopeTrait;
+
+/**
+ * @internal
+ */
+final class UpdateLoader extends AbstractLoader
+{
+    use ColumnsTrait;
+    use ScopeTrait;
+
+    protected array $options = [
+        'load' => true,
+        'scope' => true,
+    ];
+
+    /**
+     * @param non-empty-string $target Entity role or alias.
+     */
+    public function __construct(
+        SchemaInterface $ormSchema,
+        SourceProviderInterface $sourceProvider,
+        FactoryInterface $factory,
+        string $target,
+    ) {
+        parent::__construct($ormSchema, $sourceProvider, $factory, $target);
+        $this->columns = $this->normalizeColumns($this->define(SchemaInterface::COLUMNS));
+    }
+
+    public function getAlias(): string
+    {
+        return $this->target;
+    }
+
+    public function loadData(AbstractNode $node, bool $includeRole = false): void
+    {
+        // loading child datasets
+        foreach ($this->load as $relation => $loader) {
+            $loader->loadData($node->getNode($relation), $includeRole);
+        }
+
+        // $this->loadHierarchy($node, $includeRole);
+    }
+
+    public function isLoaded(): bool
+    {
+        return true;
+    }
+
+    protected function initNode(): StaticNode
+    {
+        return new StaticNode($this->columnNames(), (array) $this->define(SchemaInterface::PRIMARY_KEY));
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/BaseTest.php
+++ b/tests/ORM/Functional/Driver/Common/BaseTest.php
@@ -15,6 +15,7 @@ use Cycle\ORM\ORM;
 use Cycle\ORM\ORMInterface;
 use Cycle\ORM\Reference\ReferenceInterface;
 use Cycle\ORM\Relation;
+use Cycle\ORM\Relation\RelationLoaderInterface;
 use Cycle\ORM\Schema;
 use Cycle\ORM\SchemaInterface;
 use Cycle\ORM\Tests\Fixtures\TestLogger;
@@ -388,5 +389,10 @@ abstract class BaseTest extends TestCase
     protected function getCommandGenerator(): ?Transaction\CommandGeneratorInterface
     {
         return null;
+    }
+
+    protected function bulkLoader(object ...$entities): RelationLoaderInterface
+    {
+        return (new Relation\BulkLoader($this->orm))->collect(...$entities);
     }
 }

--- a/tests/ORM/Functional/Driver/Common/Integration/Issue356/TestCase.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Issue356/TestCase.php
@@ -33,7 +33,6 @@ abstract class TestCase extends BaseTest
 
     public function testUpdateOne(): void
     {
-        $this->enableProfiling();
         // Eager load morphed relation
         $this->captureReadQueries();
         $log = (new Select($this->orm, Entity\LogRecord::class))
@@ -68,6 +67,30 @@ abstract class TestCase extends BaseTest
         foreach ($logs as $log) {
             $this->assertInstanceOf(Entity\LogRecord::class, $log);
             self::assertInstanceOf(Entity\Actor::class, $log->actor);
+        }
+        $this->assertNumReads(0);
+    }
+
+    public function testUpdateMany(): void
+    {
+        // Eager load morphed relation
+        $this->captureReadQueries();
+        $logs = (new Select($this->orm, Entity\LogRecord::class))
+            ->fetchAll();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        (new BulkLoader($this->orm))
+            ->collect(...$logs)
+            ->load('actor')
+            ->run();
+        // 2 queries: one for users, one for tenants
+        $this->assertNumReads(2);
+
+        // Check result
+        $this->captureReadQueries();
+        foreach ($logs as $log) {
+            $this->assertInstanceOf(Entity\Actor::class, $log->actor);
         }
         $this->assertNumReads(0);
     }

--- a/tests/ORM/Functional/Driver/Common/Integration/Issue356/TestCase.php
+++ b/tests/ORM/Functional/Driver/Common/Integration/Issue356/TestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cycle\ORM\Tests\Functional\Driver\Common\Integration\Issue356;
 
+use Cycle\ORM\Relation\BulkLoader;
 use Cycle\ORM\Select;
 use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
 use Cycle\ORM\Tests\Functional\Driver\Common\Integration\IntegrationTestTrait;
@@ -27,6 +28,29 @@ abstract class TestCase extends BaseTest
         // Check result
         $this->captureReadQueries();
         $this->assertInstanceOf(Entity\LogRecord::class, $log);
+        $this->assertNumReads(0);
+    }
+
+    public function testUpdateOne(): void
+    {
+        $this->enableProfiling();
+        // Eager load morphed relation
+        $this->captureReadQueries();
+        $log = (new Select($this->orm, Entity\LogRecord::class))
+            ->wherePK(1)
+            ->fetchOne();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        (new BulkLoader($this->orm))
+            ->collect($log)
+            ->load('actor')
+            ->run();
+        $this->assertNumReads(1);
+
+        // Check result
+        $this->captureReadQueries();
+        $this->assertInstanceOf(Entity\Actor::class, $log->actor);
         $this->assertNumReads(0);
     }
 

--- a/tests/ORM/Functional/Driver/Common/Relation/BelongsTo/BelongsToNullableRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/BelongsTo/BelongsToNullableRelationTest.php
@@ -72,7 +72,6 @@ abstract class BelongsToNullableRelationTest extends BelongsToRelationTest
      */
     public function testUnsetPropertyWithoutIgnoreUninitializedRelations(): void
     {
-        echo static::class;
         $this->orm = $this->orm->with(options: (new Options())->withIgnoreUninitializedRelations(false));
         /** @var Profile $profile */
         $profile = (new Select($this->orm, Profile::class))

--- a/tests/ORM/Functional/Driver/Common/Relation/BelongsTo/BelongsToRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/BelongsTo/BelongsToRelationTest.php
@@ -416,6 +416,25 @@ abstract class BelongsToRelationTest extends BaseTest
         }
     }
 
+    public function testUpdateRelationSortedByPivot(): void
+    {
+        $this->captureReadQueries();
+        /** @var list<Profile> $profiles */
+        $profiles = (new Select($this->orm, Profile::class))->fetchAll();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        $this->bulkLoader(...$profiles)->load('user')->run();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        foreach ($profiles as $profile) {
+            $profile->user; // force loading
+            static::NULLABLE or $this->assertNotNull($profile->user);
+        }
+        $this->assertNumReads(0);
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/ORM/Functional/Driver/Common/Relation/BelongsTo/BelongsToRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/BelongsTo/BelongsToRelationTest.php
@@ -416,7 +416,7 @@ abstract class BelongsToRelationTest extends BaseTest
         }
     }
 
-    public function testUpdateRelationSortedByPivot(): void
+    public function testUpdateRelation(): void
     {
         $this->captureReadQueries();
         /** @var list<Profile> $profiles */

--- a/tests/ORM/Functional/Driver/Common/Relation/BelongsTo/BelongsToWithHasOneTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/BelongsTo/BelongsToWithHasOneTest.php
@@ -465,6 +465,28 @@ abstract class BelongsToWithHasOneTest extends BaseTest
         $this->assertSame('nested-label', $n->label);
     }
 
+    public function testUpdateNestedRelation(): void
+    {
+        $this->captureReadQueries();
+        /** @var list<Nested> $nested */
+        $nested = (new Select($this->orm, Nested::class))->fetchAll();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        $this->bulkLoader(...$nested)
+            ->load('profile.user')
+            ->run();
+        $this->assertNumReads(2);
+
+        $this->captureReadQueries();
+        foreach ($nested as $item) {
+            $this->assertNotNull($item->profile);
+            $this->assertNotNull($item->profile->user);
+            $this->assertInstanceOf(User::class, $item->profile->user);
+        }
+        $this->assertNumReads(0);
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/ORM/Functional/Driver/Common/Relation/HasMany/HasManyLoadingTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/HasMany/HasManyLoadingTest.php
@@ -137,6 +137,38 @@ abstract class HasManyLoadingTest extends BaseTest
         ], $selector->fetchData());
     }
 
+    public function testUpdateRelationSortedByPivot(): void
+    {
+        $this->captureReadQueries();
+        /** @var list<User> $users */
+        $users = (new Select($this->orm, User::class))->fetchAll();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        $this->bulkLoader(...$users)
+            ->load('comments', [
+                'orderBy' => ['id' => 'DESC'],
+            ])->run();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        $checked = false;
+        foreach ($users as $user) {
+            $this->assertIsIterable($user->comments);
+            // Check order
+            if (\count($user->comments) > 1) {
+                self::assertGreaterThan(
+                    $user->comments->offsetGet(1)->id,
+                    $user->comments->offsetGet(0)->id,
+                );
+                $checked = true;
+            }
+        }
+
+        $this->assertTrue($checked, 'No comments to check order.');
+        $this->assertNumReads(0);
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/ORM/Functional/Driver/Common/Relation/HasMany/HasManyLoadingTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/HasMany/HasManyLoadingTest.php
@@ -137,7 +137,7 @@ abstract class HasManyLoadingTest extends BaseTest
         ], $selector->fetchData());
     }
 
-    public function testUpdateRelationSortedByPivot(): void
+    public function testUpdateRelationSortedById(): void
     {
         $this->captureReadQueries();
         /** @var list<User> $users */

--- a/tests/ORM/Functional/Driver/Common/Relation/HasMany/HasManyNestedConditionTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/HasMany/HasManyNestedConditionTest.php
@@ -245,6 +245,33 @@ abstract class HasManyNestedConditionTest extends BaseTest
         ], $users->fetchData());
     }
 
+    public function testUpdateNestedRelation(): void
+    {
+        $this->captureReadQueries();
+        /** @var list<User> $users */
+        $users = (new Select($this->orm, User::class))->fetchAll();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        $this->bulkLoader(...$users)
+            ->load('posts.comments')
+            ->run();
+        $this->assertNumReads(2);
+
+        $this->captureReadQueries();
+        foreach ($users as $user) {
+            $this->assertIsIterable($user->posts);
+            foreach ($user->posts as $post) {
+                $this->assertIsIterable($post->comments);
+                // Verify comments are loaded
+                foreach ($post->comments as $comment) {
+                    $this->assertNotNull($comment->message);
+                }
+            }
+        }
+        $this->assertNumReads(0);
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/ORM/Functional/Driver/Common/Relation/HasOne/HasOneRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/HasOne/HasOneRelationTest.php
@@ -689,10 +689,8 @@ abstract class HasOneRelationTest extends BaseTest
         $this->assertNumReads(1);
 
         $this->captureReadQueries();
-        foreach ($users as $user) {
-            $user->profile; // force loading
-            static::NULLABLE or $this->assertNotNull($user->profile);
-        }
+        $this->assertNotNull($users[0]->profile);
+        static::NULLABLE and $this->assertNull($users[1]->profile);
         $this->assertNumReads(0);
     }
 

--- a/tests/ORM/Functional/Driver/Common/Relation/HasOne/HasOneRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/HasOne/HasOneRelationTest.php
@@ -675,10 +675,8 @@ abstract class HasOneRelationTest extends BaseTest
         $this->assertNull($user->profile);
     }
 
-    public function testUpdateRelationSortedByPivot(): void
+    public function testUpdateRelation(): void
     {
-        $this->enableProfiling();
-
         $this->captureReadQueries();
         /** @var list<User> $users */
         $users = (new Select($this->orm, User::class))->fetchAll();

--- a/tests/ORM/Functional/Driver/Common/Relation/HasOne/HasOneRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/HasOne/HasOneRelationTest.php
@@ -692,6 +692,31 @@ abstract class HasOneRelationTest extends BaseTest
         $this->assertNumReads(0);
     }
 
+    public function testUpdateNestedRelation(): void
+    {
+        $this->captureReadQueries();
+        /** @var list<User> $users */
+        $users = (new Select($this->orm, User::class))->fetchAll();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        $this->bulkLoader(...$users)
+            ->load('profile.nested')
+            ->run();
+        // Nested relation should be loaded in one query
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        foreach ($users as $user) {
+            if ($user->id === 1) {
+                $this->assertNotNull($user->profile);
+                $this->assertNotNull($user->profile->nested);
+                $this->assertSame('nested-label', $user->profile->nested->label);
+            }
+        }
+        $this->assertNumReads(0);
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/ORM/Functional/Driver/Common/Relation/HasOne/HasOneRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/HasOne/HasOneRelationTest.php
@@ -675,6 +675,27 @@ abstract class HasOneRelationTest extends BaseTest
         $this->assertNull($user->profile);
     }
 
+    public function testUpdateRelationSortedByPivot(): void
+    {
+        $this->enableProfiling();
+
+        $this->captureReadQueries();
+        /** @var list<User> $users */
+        $users = (new Select($this->orm, User::class))->fetchAll();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        $this->bulkLoader(...$users)->load('profile')->run();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        foreach ($users as $user) {
+            $user->profile; // force loading
+            static::NULLABLE or $this->assertNotNull($user->profile);
+        }
+        $this->assertNumReads(0);
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/ORM/Functional/Driver/Common/Relation/ManyToMany/ManyToManyLoadingTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/ManyToMany/ManyToManyLoadingTest.php
@@ -139,6 +139,38 @@ abstract class ManyToManyLoadingTest extends BaseTest
         ], $selector->fetchData());
     }
 
+    public function testUpdateRelationSortedByPivot(): void
+    {
+        $this->captureReadQueries();
+        /** @var list<User> $users */
+        $users = (new Select($this->orm, User::class))->fetchAll();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        $this->bulkLoader(...$users)
+            ->load('tags', [
+                // 'load' => function (Select\QueryBuilder $q): void {
+                //     $q->orderBy('@.@.as', 'DESC');
+                // },
+                'orderBy' => ['@.@.as' => 'DESC'],
+            ])->run();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        foreach ($users as $user) {
+            $this->assertIsIterable($user->tags);
+            $this->assertNotEmpty($user->tags);
+            // Check order
+            if (\count($user->tags) > 1) {
+                self::assertGreaterThan(
+                    $user->tags->offsetGet(1)->id,
+                    $user->tags->offsetGet(0)->id,
+                );
+            }
+        }
+        $this->assertNumReads(0);
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/ORM/Functional/Driver/Common/Relation/Morphed/BelongsToMorphedRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/Morphed/BelongsToMorphedRelationTest.php
@@ -9,6 +9,7 @@ use Cycle\ORM\Mapper\Mapper;
 use Cycle\ORM\Reference\ReferenceInterface;
 use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
+use Cycle\ORM\Select;
 use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
 use Cycle\ORM\Tests\Fixtures\Image;
 use Cycle\ORM\Tests\Fixtures\ImagedInterface;
@@ -271,6 +272,24 @@ abstract class BelongsToMorphedRelationTest extends BaseTest
         $this->orm = $this->orm->withHeap(new Heap());
         $c = $this->orm->getRepository(Image::class)->findByPK(1);
         $this->assertNull($c->parent);
+    }
+
+    public function testUpdateRelation(): void
+    {
+        $this->captureReadQueries();
+        /** @var list<Image> $images */
+        $images = (new Select($this->orm, Image::class))->fetchAll();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        $this->bulkLoader(...$images)->load('parent')->run();
+        $this->assertNumReads(2);
+
+        $this->captureReadQueries();
+        foreach ($images as $image) {
+            $this->assertNotNull($image->parent);
+        }
+        $this->assertNumReads(0);
     }
 
     public function setUp(): void

--- a/tests/ORM/Functional/Driver/Common/Relation/Morphed/MorphedHasManyRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/Morphed/MorphedHasManyRelationTest.php
@@ -388,6 +388,39 @@ abstract class MorphedHasManyRelationTest extends BaseTest
         }));
     }
 
+    public function testUpdateRelationSortedById(): void
+    {
+        $this->enableProfiling();
+        $this->captureReadQueries();
+        /** @var list<User> $users */
+        $users = (new Select($this->orm, User::class))->fetchAll();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        $this->bulkLoader(...$users)
+            ->load('comments', [
+                'orderBy' => ['id' => 'DESC'],
+            ])->run();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        $checked = false;
+        foreach ($users as $user) {
+            $this->assertIsIterable($user->comments);
+            // Check order
+            if (\count($user->comments) > 1) {
+                self::assertGreaterThan(
+                    $user->comments->offsetGet(1)->id,
+                    $user->comments->offsetGet(0)->id,
+                );
+                $checked = true;
+            }
+        }
+
+        $this->assertTrue($checked, 'No comments to check order.');
+        $this->assertNumReads(0);
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/ORM/Functional/Driver/Common/Relation/Morphed/MorphedHasManyRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/Morphed/MorphedHasManyRelationTest.php
@@ -390,7 +390,6 @@ abstract class MorphedHasManyRelationTest extends BaseTest
 
     public function testUpdateRelationSortedById(): void
     {
-        $this->enableProfiling();
         $this->captureReadQueries();
         /** @var list<User> $users */
         $users = (new Select($this->orm, User::class))->fetchAll();

--- a/tests/ORM/Functional/Driver/Common/Relation/Morphed/MorphedHasOneRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/Morphed/MorphedHasOneRelationTest.php
@@ -571,6 +571,9 @@ abstract class MorphedHasOneRelationTest extends BaseTest
                         ],
                     ],
                 ],
+                Schema::TYPECAST => [
+                    'id' => 'int',
+                ],
             ],
             Post::class => [
                 Schema::ROLE => 'post',
@@ -592,6 +595,9 @@ abstract class MorphedHasOneRelationTest extends BaseTest
                         ],
                     ],
                 ],
+                Schema::TYPECAST => [
+                    'id' => 'int',
+                ],
             ],
             Image::class => [
                 Schema::ROLE => 'image',
@@ -602,6 +608,9 @@ abstract class MorphedHasOneRelationTest extends BaseTest
                 Schema::COLUMNS => ['id', 'parent_id', 'parent_type', 'url'],
                 Schema::SCHEMA => [],
                 Schema::RELATIONS => [],
+                Schema::TYPECAST => [
+                    'id' => 'int',
+                ],
             ],
         ];
     }

--- a/tests/ORM/Functional/Driver/Common/Relation/Morphed/MorphedHasOneRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/Morphed/MorphedHasOneRelationTest.php
@@ -455,6 +455,34 @@ abstract class MorphedHasOneRelationTest extends BaseTest
         $this->assertNumReads(0);
     }
 
+    public function testUpdateNestedRelation(): void
+    {
+        $this->captureReadQueries();
+        /** @var list<User> $users */
+        $users = (new Select($this->orm, User::class))->fetchAll();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        $this->bulkLoader(...$users)
+            ->load('posts.image')
+            ->run();
+        // Nested relation will be loaded using JOIN
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        foreach ($users as $user) {
+            $this->assertIsIterable($user->posts);
+            foreach ($user->posts as $post) {
+                // Post 4 doesn't have an image
+                if ($post->id !== 4) {
+                    $this->assertNotNull($post->image);
+                    $this->assertInstanceOf(\Cycle\ORM\Tests\Fixtures\Image::class, $post->image);
+                }
+            }
+        }
+        $this->assertNumReads(0);
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/ORM/Functional/Driver/Common/Relation/Morphed/MorphedHasOneRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/Morphed/MorphedHasOneRelationTest.php
@@ -437,6 +437,24 @@ abstract class MorphedHasOneRelationTest extends BaseTest
         $this->assertSame('user-image.png', $p->image->url);
     }
 
+    public function testUpdateRelation(): void
+    {
+        $this->captureReadQueries();
+        /** @var list<User> $users */
+        $users = (new Select($this->orm, User::class))->fetchAll();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        $this->bulkLoader(...$users)->load('image')->run();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        foreach ($users as $user) {
+            $this->assertNotNull($user->image);
+        }
+        $this->assertNumReads(0);
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/ORM/Functional/Driver/Common/Relation/RefersTo/RefersToRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/RefersTo/RefersToRelationTest.php
@@ -252,6 +252,41 @@ abstract class RefersToRelationTest extends BaseTest
         $this->assertNumWrites(0);
     }
 
+    public function testUpdateRelation(): void
+    {
+        // Prepare data
+        $u = new User();
+        $u->email = 'email@email.com';
+        $u->balance = 100;
+        $c1 = new Comment();
+        $c1->message = 'last comment';
+        $c2 = new Comment();
+        $c2->message = 'new last comment';
+        $u->addComment($c1);
+        $u->addComment($c2);
+        $u->lastComment = $c2;
+        $this->save($u);
+        $this->orm->getHeap()->clean();
+        $id = $u->id;
+        unset($u, $c1, $c2);
+
+        $this->captureReadQueries();
+        /** @var User $user */
+        $user = (new Select($this->orm, User::class))->wherePK($id)->fetchOne();
+        $this->assertNumReads(1);
+
+        $this->captureReadQueries();
+        $this->bulkLoader($user)
+            ->load('lastComment')
+            ->load('comments')->run();
+        $this->assertNumReads(2);
+
+        $this->captureReadQueries();
+        $this->assertNotEmpty($user->comments);
+        $this->assertNotNull($user->lastComment);
+        $this->assertNumReads(0);
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/ORM/Unit/Relation/BulkLoaderTest.php
+++ b/tests/ORM/Unit/Relation/BulkLoaderTest.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Unit\Relation;
+
+use Cycle\ORM\Factory;
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\ORM;
+use Cycle\ORM\Relation\BulkLoader;
+use Cycle\ORM\Schema;
+use Cycle\ORM\Tests\Fixtures\User;
+use Cycle\ORM\Tests\Fixtures\Profile;
+use PHPUnit\Framework\TestCase;
+
+class BulkLoaderTest extends TestCase
+{
+    private function createORM(): ORM
+    {
+        $schema = new Schema([
+            User::class => [
+                Schema::ROLE => 'user',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'user',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'email', 'balance'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [
+                    'profile' => [
+                        \Cycle\ORM\Relation::TYPE => \Cycle\ORM\Relation::HAS_ONE,
+                        \Cycle\ORM\Relation::TARGET => Profile::class,
+                        \Cycle\ORM\Relation::SCHEMA => [
+                            \Cycle\ORM\Relation::CASCADE => true,
+                            \Cycle\ORM\Relation::INNER_KEY => 'id',
+                            \Cycle\ORM\Relation::OUTER_KEY => 'user_id',
+                        ],
+                    ],
+                ],
+            ],
+            Profile::class => [
+                Schema::ROLE => 'profile',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'profile',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'user_id', 'image'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [],
+            ],
+        ]);
+
+        return new ORM(new Factory($this->createMock(\Cycle\Database\DatabaseProviderInterface::class)), $schema);
+    }
+
+    /**
+     * Test that BulkLoader throws exception when no entities are provided
+     */
+    public function testCollectThrowsExceptionWhenNoEntitiesProvided(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('At least one entity must be provided.');
+
+        $orm = $this->createORM();
+        $loader = new BulkLoader($orm);
+        $loader->collect();
+    }
+
+    /**
+     * Test that BulkLoader throws exception when entities have different roles
+     */
+    public function testCollectThrowsExceptionWhenEntitiesHaveDifferentRoles(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('All entities must belong to the same role.');
+
+        $orm = $this->createORM();
+
+        $user = new User();
+        $profile = new Profile();
+
+        $loader = new BulkLoader($orm);
+        $loader->collect($user, $profile);
+    }
+
+    /**
+     * Test run throws exception when entity node not found in heap
+     */
+    public function testRunThrowsExceptionWhenEntityNodeNotFoundInHeap(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Entity node not found in the heap.');
+
+        $orm = $this->createORM();
+        $entity = new User();
+
+        $loader = new BulkLoader($orm);
+        $loader = $loader->collect($entity);
+        $loader->run();
+    }
+
+    /**
+     * Test collect with a single entity
+     */
+    public function testCollectWithSingleEntity(): void
+    {
+        $orm = $this->createORM();
+        $entity = new User();
+
+        $loader = new BulkLoader($orm);
+        $result = $loader->collect($entity);
+
+        $this->assertInstanceOf(BulkLoader::class, $result);
+    }
+
+    /**
+     * Test collect with multiple entities of the same role
+     */
+    public function testCollectWithMultipleEntitiesOfSameRole(): void
+    {
+        $orm = $this->createORM();
+
+        $entity1 = new User();
+        $entity2 = new User();
+        $entity3 = new User();
+
+        $loader = new BulkLoader($orm);
+        $result = $loader->collect($entity1, $entity2, $entity3);
+
+        $this->assertInstanceOf(BulkLoader::class, $result);
+    }
+
+    /**
+     * Test collect returns a new instance (immutability)
+     */
+    public function testCollectReturnsNewInstance(): void
+    {
+        $orm = $this->createORM();
+
+        $loader1 = new BulkLoader($orm);
+        $entity = new User();
+        $loader2 = $loader1->collect($entity);
+
+        $this->assertNotSame($loader1, $loader2, 'collect() should return a new instance');
+    }
+
+    /**
+     * Test chaining multiple collect calls
+     */
+    public function testChainingMultipleCollectCalls(): void
+    {
+        $orm = $this->createORM();
+
+        $entity1 = new User();
+        $entity2 = new User();
+
+        $loader = new BulkLoader($orm);
+        $loader1 = $loader->collect($entity1);
+        $loader2 = $loader1->collect($entity2);
+
+        $this->assertNotSame($loader, $loader1);
+        $this->assertNotSame($loader1, $loader2);
+        $this->assertInstanceOf(BulkLoader::class, $loader2);
+    }
+
+    /**
+     * Test collect with empty array (edge case)
+     */
+    public function testCollectWithEmptyArrayUnpacking(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('At least one entity must be provided.');
+
+        $orm = $this->createORM();
+        $entities = [];
+
+        $loader = new BulkLoader($orm);
+        $loader->collect(...$entities);
+    }
+
+    /**
+     * Test that collect merges entities from multiple calls
+     */
+    public function testCollectMergesEntities(): void
+    {
+        $orm = $this->createORM();
+
+        $entity1 = new User();
+        $entity2 = new User();
+        $entity3 = new User();
+
+        $loader = new BulkLoader($orm);
+        $loader = $loader->collect($entity1);
+        $loader = $loader->collect($entity2, $entity3);
+
+        // Should not throw exception - all entities should be collected
+        $this->assertInstanceOf(BulkLoader::class, $loader);
+    }
+
+    /**
+     * Test load returns the same instance (fluent interface)
+     */
+    public function testLoadReturnsSameInstance(): void
+    {
+        $orm = $this->createORM();
+
+        $entity = new User();
+        $loader = new BulkLoader($orm);
+        $loader = $loader->collect($entity);
+        $loaderAfterLoad = $loader->load('profile');
+
+        $this->assertSame($loader, $loaderAfterLoad, 'load() should return the same instance');
+    }
+
+    /**
+     * Test chaining load calls
+     */
+    public function testChainingLoadCalls(): void
+    {
+        $orm = $this->createORM();
+
+        $entity = new User();
+        $loader = new BulkLoader($orm);
+        $loader = $loader->collect($entity);
+        $result = $loader->load('profile')->load('profile'); // Load same relation twice
+
+        $this->assertSame($loader, $result);
+    }
+
+    /**
+     * Test load with custom options
+     */
+    public function testLoadWithCustomOptions(): void
+    {
+        $orm = $this->createORM();
+
+        $entity = new User();
+        $loader = new BulkLoader($orm);
+        $loader = $loader->collect($entity);
+        $result = $loader->load('profile', ['where' => ['id' => 1]]);
+
+        $this->assertSame($loader, $result);
+    }
+}

--- a/tests/ORM/Unit/Relation/BulkLoaderTest.php
+++ b/tests/ORM/Unit/Relation/BulkLoaderTest.php
@@ -15,44 +15,6 @@ use PHPUnit\Framework\TestCase;
 
 class BulkLoaderTest extends TestCase
 {
-    private function createORM(): ORM
-    {
-        $schema = new Schema([
-            User::class => [
-                Schema::ROLE => 'user',
-                Schema::MAPPER => Mapper::class,
-                Schema::DATABASE => 'default',
-                Schema::TABLE => 'user',
-                Schema::PRIMARY_KEY => 'id',
-                Schema::COLUMNS => ['id', 'email', 'balance'],
-                Schema::SCHEMA => [],
-                Schema::RELATIONS => [
-                    'profile' => [
-                        \Cycle\ORM\Relation::TYPE => \Cycle\ORM\Relation::HAS_ONE,
-                        \Cycle\ORM\Relation::TARGET => Profile::class,
-                        \Cycle\ORM\Relation::SCHEMA => [
-                            \Cycle\ORM\Relation::CASCADE => true,
-                            \Cycle\ORM\Relation::INNER_KEY => 'id',
-                            \Cycle\ORM\Relation::OUTER_KEY => 'user_id',
-                        ],
-                    ],
-                ],
-            ],
-            Profile::class => [
-                Schema::ROLE => 'profile',
-                Schema::MAPPER => Mapper::class,
-                Schema::DATABASE => 'default',
-                Schema::TABLE => 'profile',
-                Schema::PRIMARY_KEY => 'id',
-                Schema::COLUMNS => ['id', 'user_id', 'image'],
-                Schema::SCHEMA => [],
-                Schema::RELATIONS => [],
-            ],
-        ]);
-
-        return new ORM(new Factory($this->createMock(\Cycle\Database\DatabaseProviderInterface::class)), $schema);
-    }
-
     /**
      * Test that BulkLoader throws exception when no entities are provided
      */
@@ -240,5 +202,43 @@ class BulkLoaderTest extends TestCase
         $result = $loader->load('profile', ['where' => ['id' => 1]]);
 
         $this->assertSame($loader, $result);
+    }
+
+    private function createORM(): ORM
+    {
+        $schema = new Schema([
+            User::class => [
+                Schema::ROLE => 'user',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'user',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'email', 'balance'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [
+                    'profile' => [
+                        \Cycle\ORM\Relation::TYPE => \Cycle\ORM\Relation::HAS_ONE,
+                        \Cycle\ORM\Relation::TARGET => Profile::class,
+                        \Cycle\ORM\Relation::SCHEMA => [
+                            \Cycle\ORM\Relation::CASCADE => true,
+                            \Cycle\ORM\Relation::INNER_KEY => 'id',
+                            \Cycle\ORM\Relation::OUTER_KEY => 'user_id',
+                        ],
+                    ],
+                ],
+            ],
+            Profile::class => [
+                Schema::ROLE => 'profile',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'profile',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'user_id', 'image'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [],
+            ],
+        ]);
+
+        return new ORM(new Factory($this->createMock(\Cycle\Database\DatabaseProviderInterface::class)), $schema);
     }
 }


### PR DESCRIPTION
# 🔍 What was changed

Added relations bulk loader to load relations

# 📝 Checklist

<!--- add/delete as needed --->

- Closes #488
- How was this tested:
  - [x] Tested manually
  - [x] Unit tests added

# 📃 Documentation: Bulk Loading Relations

When you fetch multiple entities and need to load their relations, doing it one by one causes the N+1 query problem.
BulkLoader solves this by loading relations for all entities at once.
Only unloaded relations are resolved - already loaded relations won't be overwritten.

## Getting BulkLoader Instance

To load relations, use the `\Cycle\ORM\Relation\BulkLoaderInterface`.

If you're using a Cycle ORM bridge, get the BulkLoader instance from the DI container:

```php
use Cycle\ORM\Relation\BulkLoaderInterface;

final class Service
{
    public function __construct(
        private BulkLoaderInterface $bulkLoader
    ) {}
}
```

If you're not using a bridge, configure the binding in your application container:

```php
// Container configuration
$container->bindSingleton(
    \Cycle\ORM\Relation\BulkLoaderInterface::class,
    \Cycle\ORM\Relation\BulkLoader::class
);
```

Then inject it into your services as shown above.

## Basic Usage

The `BulkLoaderInterface::collect()` method is immutable and returns a new instance
of `Cycle\ORM\Relation\RelationLoaderInterface` that you can use to chain `load()` calls and finally execute `run()`.

```php
$users = $userRepository->findAll();

$bulkLoader
    ->collect(...$users)
    ->load('profile')
    ->run();

foreach ($users as $user) {
    echo $user->profile->imageUrl; // No extra queries
}
```

This executes just 2 queries instead of 1 + N: one to fetch users, one to fetch all their profiles.

## Multiple and Nested Relations

```php
// Multiple relations
$bulkLoader
    ->collect(...$users)
    ->load('profile')
    ->load('comments')
    ->load('posts')
    ->run();

// Nested relations
$bulkLoader
    ->collect(...$users)
    ->load('posts.comments')
    ->run();

// With options
$bulkLoader
    ->collect(...$users)
    ->load('comments', [
        'orderBy' => ['created_at' => 'DESC'],
        'where' => ['approved' => true]
    ])
    ->run();

// Sort by pivot columns (many-to-many)
$bulkLoader
    ->collect(...$users)
    ->load('tags', ['orderBy' => ['@.@.created_at' => 'DESC']])
    ->run();
```

## Important Behavior

- All entities must be of the same role.
- Entities must be loaded from the database (not new).

    ```php
    $user = new User(); // not persisted or fetched

    $bulkLoader
        ->collect($user)
        ->load('profile')
        ->run(); // LogicException
    ```

- Relations use database state, not runtime changes. It's required because to ensure consistency.

    ```php
    $profile = $profileRepository->findByPK(1); // user_id = 5 in DB
    $profile->user_id = 10; // changed at runtime

    $bulkLoader->collect($profile)->load('user')->run();

    // $profile->user still points to User(5), not User(10)
    ```

- Already loaded relations are not overwritten:

    ```php
    $user = $userRepository->findByPK(1);
    $user->profile; // lazy loading triggered

    $bulkLoader->collect($user)->load('profile')->run();

    // $user->profile is the same instance, not reloaded
    ```
