### PR TITLE
Handle empty entity collection without throwing exception

### DIFF
--- a/src/Relation/BulkLoader.php
+++ b/src/Relation/BulkLoader.php
@@ -29,7 +29,16 @@ final class BulkLoader implements BulkLoaderInterface, RelationLoaderInterface
 
     public function collect(object ...$entities): RelationLoaderInterface
     {
-        $entities === [] and throw new \InvalidArgumentException('At least one entity must be provided.');
+        if ($entities === []) {
+            return new class implements RelationLoaderInterface {
+                public function load(string $relation, array $options = []): static
+                {
+                    return $this;
+                }
+
+                public function run(): void {}
+            };
+        }
         $entities = \array_values($entities);
 
         // Validate entity roles
@@ -112,7 +121,7 @@ final class BulkLoader implements BulkLoaderInterface, RelationLoaderInterface
      * @param non-empty-array<non-empty-string> $keys
      * @param non-empty-array<non-empty-string> $data
      */
-    public function indexEntity(Node $node, array $keys, array $data, object $entity): void
+    private function indexEntity(Node $node, array $keys, array $data, object $entity): void
     {
         $pool = &$this->index;
         foreach ($keys as $k) {

--- a/src/Relation/BulkLoaderInterface.php
+++ b/src/Relation/BulkLoaderInterface.php
@@ -12,6 +12,8 @@ interface BulkLoaderInterface
     /**
      * Collect entities for bulk relation loading.
      *
+     * If no entities are provided, a no-op loader is returned.
+     *
      * @param object ...$entities Entities to collect
      * @psalm-immutable
      */

--- a/tests/ORM/Unit/Relation/BulkLoaderTest.php
+++ b/tests/ORM/Unit/Relation/BulkLoaderTest.php
@@ -8,6 +8,7 @@ use Cycle\ORM\Factory;
 use Cycle\ORM\Mapper\Mapper;
 use Cycle\ORM\ORM;
 use Cycle\ORM\Relation\BulkLoader;
+use Cycle\ORM\Relation\RelationLoaderInterface;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Tests\Fixtures\User;
 use Cycle\ORM\Tests\Fixtures\Profile;
@@ -130,14 +131,12 @@ class BulkLoaderTest extends TestCase
      */
     public function testCollectWithEmptyArrayUnpacking(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('At least one entity must be provided.');
-
         $orm = $this->createORM();
-        $entities = [];
+        $loader = (new BulkLoader($orm))->collect();
 
-        $loader = new BulkLoader($orm);
-        $loader->collect(...$entities);
+        self::assertInstanceOf(RelationLoaderInterface::class, $loader);
+        $loader->load('profile');
+        $loader->run();
     }
 
     /**


### PR DESCRIPTION
## 🔍 What was changed

Handle empty entity collection without throwing exception in BulkLoader

## 🤔 Why?

No one checks count of related objects before using BulkLoader

## 📝 Checklist

<!--- add/delete as needed --->

- Closes #<!-- add issue number here -->
- How was this tested:
  - [ ] Tested manually
  - [x] Unit tests added
