### PR TITLE
UnitOfWork: Add `hasPendingChanges()` method

### DIFF
--- a/src/Transaction/UnitOfWork.php
+++ b/src/Transaction/UnitOfWork.php
@@ -137,6 +137,19 @@ final class UnitOfWork implements StateInterface
     }
 
     /**
+     * Check if there are pending changes in the unit of work.
+     *
+     * @return bool True if there are pending changes, false otherwise.
+     *         In case the transaction is finished, it will always return false.
+     *         In case the transaction is in process, it will always return true.
+     *         In case of failure, it will return true and pending changes can be retried.
+     */
+    public function hasPendingChanges(): bool
+    {
+        return isset($this->pool) && $this->pool->count() > 0;
+    }
+
+    /**
      * @throws TransactionException
      */
     private function checkActionPossibility(string $action): void

--- a/tests/ORM/Functional/Driver/Common/Transaction/UnitOfWorkTest.php
+++ b/tests/ORM/Functional/Driver/Common/Transaction/UnitOfWorkTest.php
@@ -44,6 +44,32 @@ abstract class UnitOfWorkTest extends BaseTest
         $this->assertNull($result->getLastError());
     }
 
+    public function testPendingChanges(): void
+    {
+        $eow = new UnitOfWork($this->orm, Runner::outerTransaction());
+
+        $entity = new Post();
+        $entity->title = 'Test title';
+        $entity->content = 'Test';
+
+        $eow->persistState($entity);
+
+        $this->assertTrue($eow->hasPendingChanges());
+
+        $result = $eow->run();
+        $this->assertTrue($eow->hasPendingChanges());
+        $this->assertFalse($result->isSuccess());
+        $this->assertInstanceOf(RunnerException::class, $result->getLastError());
+
+        $this->getDriver()->beginTransaction();
+
+        $result = $result->retry();
+
+        $this->assertFalse($eow->hasPendingChanges());
+        $this->assertTrue($result->isSuccess());
+        $this->assertNull($result->getLastError());
+    }
+
     public function testParallelPersist(): void
     {
         $eow = new UnitOfWork($this->orm);


### PR DESCRIPTION
## 🔍 What was changed

Added `\Cycle\ORM\Transaction\UnitOfWork::hasPendingChanges()`

```php
    /**
     * Check if there are pending changes in the unit of work.
     *
     * @return bool True if there are pending changes, false otherwise.
     *         In case the transaction is finished, it will always return false.
     *         In case the transaction is in process, it will always return true.
     *         In case of failure, it will return true and pending changes can be retried.
     */
    public function hasPendingChanges(): bool
```


