### PR TITLE
Add options DTOs for `Select::load()` method

### DIFF
--- a/.github/workflows/ci-mssql.yml
+++ b/.github/workflows/ci-mssql.yml
@@ -12,5 +12,7 @@ name: MSSQL
 jobs:
   phpunit:
     uses: cycle/gh-actions/.github/workflows/db-mssql.yml@master
+    with:
+      php: '["8.1","8.2","8.3","8.4","8.5"]'
 
 ...

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -12,5 +12,7 @@ name: MySQL
 jobs:
   phpunit:
     uses: cycle/gh-actions/.github/workflows/db-mysql.yml@master
+    with:
+      php: '["8.1","8.2","8.3","8.4","8.5"]'
 
 ...

--- a/.github/workflows/ci-pgsql.yml
+++ b/.github/workflows/ci-pgsql.yml
@@ -12,5 +12,7 @@ name: Postgres
 jobs:
   phpunit:
     uses: cycle/gh-actions/.github/workflows/db-pgsql.yml@master
+    with:
+      php: '["8.1","8.2","8.3","8.4","8.5"]'
 
 ...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Install ODBC driver.
         run: |
           sudo curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
+          sudo apt-get clean
+          sudo apt-get update
           sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
 
       - name: 📦 Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,6 @@ jobs:
           - ubuntu-latest
 
         php-version:
-          - "8.0"
           - "8.1"
           - "8.2"
           - "8.3"
@@ -82,7 +81,6 @@ jobs:
           - ubuntu-latest
 
         php-version:
-          - "8.0"
           - "8.1"
           - "8.2"
           - "8.3"

--- a/composer.json
+++ b/composer.json
@@ -38,23 +38,23 @@
         }
     ],
     "require": {
-        "php": ">=8.0",
-        "ext-pdo": "*",
+        "php": ">=8.1",
         "cycle/database": "^2.8.1",
         "doctrine/instantiator": "^1.3.1 || ^2.0",
         "spiral/core": "^2.8 || ^3.0"
     },
     "require-dev": {
+        "ext-pdo": "*",
+        "buggregator/trap": "^1.15",
         "doctrine/collections": "^1.6 || ^2.0",
-        "illuminate/collections": "9 - 11",
+        "illuminate/collections": "9 - 12",
         "loophp/collection": "^6.0 || ^7.0",
         "mockery/mockery": "^1.1",
         "phpunit/phpunit": "^9.5",
         "ramsey/uuid": "^4.0",
         "spiral/code-style": "~2.2.0",
         "spiral/tokenizer": "^2.8 || ^3.0",
-        "symfony/var-dumper": "^5.2 || ^6.0 || ^7.0",
-        "vimeo/psalm": "5.21 || ^6.8"
+        "vimeo/psalm": "^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Select.php
+++ b/src/Select.php
@@ -7,6 +7,7 @@ namespace Cycle\ORM;
 use Cycle\Database\Injection\Parameter;
 use Cycle\Database\Query\SelectQuery;
 use Cycle\ORM\Heap\Node;
+use Cycle\ORM\Select\Options\LoadOptions;
 use Cycle\ORM\Service\EntityFactoryInterface;
 use Cycle\ORM\Service\MapperProviderInterface;
 use Cycle\ORM\Service\SourceProviderInterface;
@@ -230,7 +231,7 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
      *
      * @return static<TEntity>
      */
-    public function load(string|array $relation, array $options = []): self
+    public function load(array|string $relation, LoadOptions|array $options = []): self
     {
         if (\is_string($relation)) {
             $this->loader->loadRelation($relation, $options, false, true);
@@ -244,7 +245,7 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
                 $this->load($subOption, $options);
             } else {
                 // multiple relations or relation with addition load options
-                $this->load($name, $subOption + $options);
+                $this->load($name, $subOption + $mergeOptions);
             }
         }
 

--- a/src/Select.php
+++ b/src/Select.php
@@ -178,54 +178,55 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
     }
 
     /**
-     * Request primary selector loader to pre-load relation name. Any type of loader can be used
-     * for data pre-loading. ORM loaders by default will select the most efficient way to load
-     * related data which might include additional select query or left join. Loaded data will
-     * automatically pre-populate record relations. You can specify nested relations using "."
-     * separator.
+     * Pre-load related data for the given relation(s).
      *
-     * Examples:
+     * The loader automatically selects the most efficient strategy (additional query or JOIN).
+     * Loaded data is populated into entity relations. Use "." to specify nested relations.
      *
-     *     // Select users and load their comments (will cast 2 queries, HAS_MANY comments)
-     *     User::find()->with('comments');
+     * Use typed DTO options for a safe, discoverable API:
      *
-     *     // You can load chain of relations - select user and load their comments and post related to comment
-     *     User::find()->with('comments.post');
+     *     use Cycle\ORM\Select\Options\HasManyLoadOptions;
+     *     use Cycle\ORM\Select\Options\LoadMethod;
      *
-     *     // We can also specify custom where conditions on data loading, let's load only public comments.
-     *     User::find()->load('comments', [
-     *         'where' => ['{@}.status' => 'public']
-     *     ]);
+     *     // Load comments using a separate query (default for HasMany)
+     *     $select->load('comments', new HasManyLoadOptions());
      *
-     * Please note using "{@}" column name, this placeholder is required to prevent collisions and
-     * it will be automatically replaced with valid table alias of pre-loaded comments table.
+     *     // Force loading within the same query via JOIN
+     *     $select->load('comments', new HasManyLoadOptions(
+     *         method: LoadMethod::SingleQuery,
+     *     ));
      *
-     *     // In case where your loaded relation is MANY_TO_MANY you can also specify pivot table
-     *     // conditions, let's pre-load all approved user tags, we can use same placeholder for pivot
-     *     // table alias
-     *     User::find()->load('tags', [
-     *          'wherePivot' => ['{@}.approved' => true]
-     *     ]);
+     *     // Custom WHERE / ORDER BY
+     *     $select->load('comments', new HasManyLoadOptions(
+     *         where: ['@.status' => 'public'],
+     *         orderBy: ['@.created_at' => 'DESC'],
+     *     ));
      *
-     *     // In most of cases you don't need to worry about how data was loaded, using external query
-     *     // or left join, however if you want to change such behaviour you can force load method
-     *     // using {@see Select::SINGLE_QUERY}
-     *     User::find()->load('tags', [
-     *          'method'     => Select::SINGLE_QUERY,
-     *          'wherePivot' => ['{@}.approved' => true]
-     *     ]);
+     *     // Load from an archive table
+     *     $select->load('comments', new HasManyLoadOptions(
+     *         table: 'comment_archive',
+     *     ));
      *
-     * Attention, you will not be able to correctly paginate in this case and only ORM loaders
-     * support different loading types.
+     * Available DTO classes (one per relation type):
+     * - {@see \Cycle\ORM\Select\Options\HasOneLoadOptions}
+     * - {@see \Cycle\ORM\Select\Options\HasManyLoadOptions}
+     * - {@see \Cycle\ORM\Select\Options\BelongsToLoadOptions}
+     * - {@see \Cycle\ORM\Select\Options\ManyToManyLoadOptions}
+     * - {@see \Cycle\ORM\Select\Options\MorphedHasOneLoadOptions}
+     * - {@see \Cycle\ORM\Select\Options\MorphedHasManyLoadOptions}
+     * - {@see \Cycle\ORM\Select\Options\BelongsToMorphedLoadOptions}
      *
-     * You can specify multiple loaders using array as first argument.
+     * Raw array options are still supported for backwards compatibility:
      *
-     * Example:
+     *     $select->load('comments', ['where' => ['@.status' => 'public']]);
      *
-     *     User::find()->load(['posts', 'comments', 'profile']);
+     * Multiple relations can be loaded at once. The second argument applies
+     * shared options to every relation in the list:
      *
-     * Attention, consider disabling entity map if you want to use recursive loading (i.e
-     * post.tags.posts), but first think why you even need recursive relation loading.
+     *     $select->load(['posts', 'comments', 'profile']);
+     *     $select->load(['posts', 'comments'], new JoinableLoadOptions(
+     *         method: LoadMethod::SingleQuery,
+     *     ));
      *
      * @see with()
      *

--- a/src/Select.php
+++ b/src/Select.php
@@ -245,7 +245,7 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
                 $this->load($subOption, $options);
             } else {
                 // multiple relations or relation with addition load options
-                $this->load($name, $subOption + $mergeOptions);
+                $this->load($name, $subOption);
             }
         }
 

--- a/src/Select/AbstractLoader.php
+++ b/src/Select/AbstractLoader.php
@@ -86,6 +86,8 @@ abstract class AbstractLoader implements LoaderInterface
      */
     protected array $children;
 
+    /** @var non-empty-string */
+    protected string $table;
     protected SourceInterface $source;
 
     public function __construct(
@@ -100,6 +102,7 @@ abstract class AbstractLoader implements LoaderInterface
     ) {
         $this->children = $this->ormSchema->getInheritedRoles($target);
         $this->source = $this->sourceProvider->getSource($target);
+        $this->table = $this->source->getTable();
     }
 
     public function isHierarchical(): bool
@@ -209,6 +212,11 @@ abstract class AbstractLoader implements LoaderInterface
         }
 
         try {
+            if (isset($options['table'])) {
+                $table = $options['table'];
+                unset($options['table']);
+            }
+
             // Creating new loader.
             $loader = $this->factory->loader(
                 $this->ormSchema,
@@ -216,6 +224,9 @@ abstract class AbstractLoader implements LoaderInterface
                 $this->target,
                 $relation,
             );
+
+            // Apply table name if provided
+            isset($table) && $loader instanceof self and $loader->table = $table;
         } catch (SchemaException | FactoryException $e) {
             if ($this->inherit instanceof self) {
                 return $this->inherit->loadRelation($relation, $options, $join, $load, $alias);
@@ -227,7 +238,8 @@ abstract class AbstractLoader implements LoaderInterface
             );
         }
 
-        return $loaders[$alias] = $loader->withContext($this, $options);
+        $loader = $loader->withContext($this, $options);
+        return $loaders[$alias] = $loader;
     }
 
     public function createNode(): AbstractNode
@@ -264,6 +276,13 @@ abstract class AbstractLoader implements LoaderInterface
     public function getSource(): SourceInterface
     {
         return $this->source;
+    }
+
+    public function withSource(SourceInterface $source): static
+    {
+        $clone = clone $this;
+        $clone->source = $source;
+        return $clone;
     }
 
     /**

--- a/src/Select/AbstractLoader.php
+++ b/src/Select/AbstractLoader.php
@@ -88,6 +88,7 @@ abstract class AbstractLoader implements LoaderInterface
 
     /** @var non-empty-string */
     protected string $table;
+
     protected SourceInterface $source;
 
     public function __construct(

--- a/src/Select/AbstractLoader.php
+++ b/src/Select/AbstractLoader.php
@@ -10,6 +10,7 @@ use Cycle\ORM\Exception\LoaderException;
 use Cycle\ORM\Exception\SchemaException;
 use Cycle\ORM\FactoryInterface;
 use Cycle\ORM\Parser\AbstractNode;
+use Cycle\ORM\Select\Options\LoadOptions;
 use Cycle\ORM\Service\SourceProviderInterface;
 use Cycle\ORM\Relation;
 use Cycle\ORM\SchemaInterface;
@@ -150,10 +151,14 @@ abstract class AbstractLoader implements LoaderInterface
      */
     public function loadRelation(
         string|LoaderInterface $relation,
-        array $options,
+        LoadOptions|array $options,
         bool $join = false,
         bool $load = false,
     ): LoaderInterface {
+        if ($options instanceof LoadOptions) {
+            $options = $options->toArray();
+        }
+
         if ($relation instanceof ParentLoader) {
             return $this->inherit = $relation->withContext($this);
         }

--- a/src/Select/JoinableLoader.php
+++ b/src/Select/JoinableLoader.php
@@ -312,7 +312,7 @@ abstract class JoinableLoader extends AbstractLoader implements JoinableInterfac
      */
     protected function getJoinTable(): string
     {
-        return "{$this->define(SchemaInterface::TABLE)} AS {$this->getAlias()}";
+        return "{$this->table} AS {$this->getAlias()}";
     }
 
     private function makeQueryBuilder(SelectQuery $query): QueryBuilder

--- a/src/Select/Loader/ManyToManyLoader.php
+++ b/src/Select/Loader/ManyToManyLoader.php
@@ -15,6 +15,7 @@ use Cycle\ORM\Relation;
 use Cycle\ORM\SchemaInterface;
 use Cycle\ORM\Select\JoinableLoader;
 use Cycle\ORM\Select\LoaderInterface;
+use Cycle\ORM\Select\Options\LoadOptions;
 use Cycle\ORM\Select\Traits\OrderByTrait;
 use Cycle\ORM\Select\Traits\WhereTrait;
 
@@ -81,10 +82,14 @@ class ManyToManyLoader extends JoinableLoader
 
     public function loadRelation(
         string|LoaderInterface $relation,
-        array $options,
+        LoadOptions|array $options,
         bool $join = false,
         bool $load = false,
     ): LoaderInterface {
+        if ($options instanceof LoadOptions) {
+            $options = $options->toArray();
+        }
+
         if ($relation === '@' || $relation === '@.@') {
             unset($options['method']);
             if ($options !== []) {

--- a/src/Select/Loader/SubQueryLoader.php
+++ b/src/Select/Loader/SubQueryLoader.php
@@ -51,7 +51,7 @@ final class SubQueryLoader extends JoinableLoader
         $queryColumns = $query->getColumns();
 
         $body = $this->loader->source->getDatabase()->select()->from(
-            \sprintf('%s AS %s', $this->loader->source->getTable(), $lAlias),
+            \sprintf('%s AS %s', $this->table, $lAlias),
         )->columns($queryColumns);
         $body = $this->loader->configureQuery($body);
         $bodyColumns = \array_slice($body->getColumns(), \count($queryColumns));

--- a/src/Select/Options/BelongsToLoadOptions.php
+++ b/src/Select/Options/BelongsToLoadOptions.php
@@ -51,4 +51,11 @@ final class BelongsToLoadOptions extends JoinableLoadOptions
     ) {
         parent::__construct($method, $scope, $minify, $as, $using);
     }
+
+    public function toArray(): array
+    {
+        return [
+            'where' => $this->where,
+        ] + parent::toArray();
+    }
 }

--- a/src/Select/Options/BelongsToLoadOptions.php
+++ b/src/Select/Options/BelongsToLoadOptions.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Select\Options;
+
+use Cycle\ORM\Select\ScopeInterface;
+
+/**
+ * Load options for BelongsTo relations.
+ *
+ * Note: BelongsToMorphed uses a different loading mechanism and does not support these options.
+ */
+final class BelongsToLoadOptions extends JoinableLoadOptions
+{
+    public function __construct(
+        /**
+         * Defines how to load relation data: within the same query (JOIN) or using a separate query.
+         */
+        LoadMethod|JoinMethod|null $method = LoadMethod::OuterQuery,
+
+        /**
+         * Scope applied to the relation query.
+         * - `true` — use the default scope from the source (default)
+         * - `false` — disable scope
+         * - `ScopeInterface` — use a custom scope instance
+         */
+        ScopeInterface|bool $scope = true,
+
+        /**
+         * When true, loader column aliases will be minified in SQL output.
+         */
+        bool $minify = true,
+
+        /**
+         * Custom table alias for the relation in SQL.
+         * Calculated automatically if not set.
+         */
+        ?string $as = null,
+
+        /**
+         * Use an alias defined by another relation (typically from {@see \Cycle\ORM\Select::with()})
+         * as the data source instead of generating a new JOIN or query.
+         */
+        ?string $using = null,
+
+        /**
+         * Additional WHERE conditions for the relation query.
+         */
+        public ?array $where = null,
+    ) {
+        parent::__construct($method, $scope, $minify, $as, $using);
+    }
+}

--- a/src/Select/Options/BelongsToLoadOptions.php
+++ b/src/Select/Options/BelongsToLoadOptions.php
@@ -50,8 +50,16 @@ final class BelongsToLoadOptions extends JoinableLoadOptions
          * Additional WHERE conditions for the relation query.
          */
         public ?array $where = null,
+
+        /**
+         * Override the table name for loading related entities.
+         * Useful for loading data from archive tables or alternative storage.
+         *
+         * @var non-empty-string|null
+         */
+        ?string $table = null,
     ) {
-        parent::__construct($method, $scope, $minify, $as, $using);
+        parent::__construct($method, $scope, $minify, $as, $using, $table);
     }
 
     public function toArray(): array

--- a/src/Select/Options/BelongsToLoadOptions.php
+++ b/src/Select/Options/BelongsToLoadOptions.php
@@ -56,8 +56,8 @@ final class BelongsToLoadOptions extends JoinableLoadOptions
 
     public function toArray(): array
     {
-        return \array_filter([
-            'where' => $this->where,
-        ]) + parent::toArray();
+        $result = parent::toArray();
+        $this->where === null or $result['where'] = $this->where;
+        return $result;
     }
 }

--- a/src/Select/Options/BelongsToLoadOptions.php
+++ b/src/Select/Options/BelongsToLoadOptions.php
@@ -29,6 +29,8 @@ final class BelongsToLoadOptions extends JoinableLoadOptions
 
         /**
          * When true, loader column aliases will be minified in SQL output.
+         * @note Intended for debugging purposes. Use with caution: disabling minification
+         *       may cause column name conflicts between different relations.
          */
         bool $minify = true,
 
@@ -54,8 +56,8 @@ final class BelongsToLoadOptions extends JoinableLoadOptions
 
     public function toArray(): array
     {
-        return [
+        return \array_filter([
             'where' => $this->where,
-        ] + parent::toArray();
+        ]) + parent::toArray();
     }
 }

--- a/src/Select/Options/BelongsToMorphedLoadOptions.php
+++ b/src/Select/Options/BelongsToMorphedLoadOptions.php
@@ -4,30 +4,10 @@ declare(strict_types=1);
 
 namespace Cycle\ORM\Select\Options;
 
-use Cycle\ORM\Select\ScopeInterface;
-
 /**
  * Load options for BelongsToMorphed relations.
  *
  * This relation uses a separate loading mechanism (not JoinableLoader),
  * so it only supports a limited set of options.
  */
-final class BelongsToMorphedLoadOptions extends LoadOptions
-{
-    public function __construct(
-        /**
-         * Scope applied to the relation query.
-         * - `true` — use the default scope from the source (default)
-         * - `false` — disable scope
-         * - `ScopeInterface` — use a custom scope instance
-         */
-        ScopeInterface|bool $scope = true,
-
-        /**
-         * When true, loader column aliases will be minified in SQL output.
-         */
-        bool $minify = true,
-    ) {
-        parent::__construct($scope, $minify);
-    }
-}
+final class BelongsToMorphedLoadOptions extends LoadOptions {}

--- a/src/Select/Options/BelongsToMorphedLoadOptions.php
+++ b/src/Select/Options/BelongsToMorphedLoadOptions.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Select\Options;
+
+use Cycle\ORM\Select\ScopeInterface;
+
+/**
+ * Load options for BelongsToMorphed relations.
+ *
+ * This relation uses a separate loading mechanism (not JoinableLoader),
+ * so it only supports a limited set of options.
+ */
+final class BelongsToMorphedLoadOptions extends LoadOptions
+{
+    public function __construct(
+        /**
+         * Scope applied to the relation query.
+         * - `true` — use the default scope from the source (default)
+         * - `false` — disable scope
+         * - `ScopeInterface` — use a custom scope instance
+         */
+        ScopeInterface|bool $scope = true,
+
+        /**
+         * When true, loader column aliases will be minified in SQL output.
+         */
+        bool $minify = true,
+    ) {
+        parent::__construct($scope, $minify);
+    }
+}

--- a/src/Select/Options/HasManyLoadOptions.php
+++ b/src/Select/Options/HasManyLoadOptions.php
@@ -54,4 +54,12 @@ final class HasManyLoadOptions extends JoinableLoadOptions
     ) {
         parent::__construct($method, $scope, $minify, $as, $using);
     }
+
+    public function toArray(): array
+    {
+        return [
+            'where' => $this->where,
+            'orderBy' => $this->orderBy,
+        ] + parent::toArray();
+    }
 }

--- a/src/Select/Options/HasManyLoadOptions.php
+++ b/src/Select/Options/HasManyLoadOptions.php
@@ -53,8 +53,16 @@ final class HasManyLoadOptions extends JoinableLoadOptions
          * ORDER BY rules for the relation query.
          */
         public ?array $orderBy = null,
+
+        /**
+         * Override the table name for loading related entities.
+         * Useful for loading data from archive tables or alternative storage.
+         *
+         * @var non-empty-string|null
+         */
+        ?string $table = null,
     ) {
-        parent::__construct($method, $scope, $minify, $as, $using);
+        parent::__construct($method, $scope, $minify, $as, $using, $table);
     }
 
     public function toArray(): array

--- a/src/Select/Options/HasManyLoadOptions.php
+++ b/src/Select/Options/HasManyLoadOptions.php
@@ -27,6 +27,8 @@ final class HasManyLoadOptions extends JoinableLoadOptions
 
         /**
          * When true, loader column aliases will be minified in SQL output.
+         * @note Intended for debugging purposes. Use with caution: disabling minification
+         *       may cause column name conflicts between different relations.
          */
         bool $minify = true,
 
@@ -57,9 +59,9 @@ final class HasManyLoadOptions extends JoinableLoadOptions
 
     public function toArray(): array
     {
-        return [
+        return \array_filter([
             'where' => $this->where,
             'orderBy' => $this->orderBy,
-        ] + parent::toArray();
+        ]) + parent::toArray();
     }
 }

--- a/src/Select/Options/HasManyLoadOptions.php
+++ b/src/Select/Options/HasManyLoadOptions.php
@@ -59,9 +59,9 @@ final class HasManyLoadOptions extends JoinableLoadOptions
 
     public function toArray(): array
     {
-        return \array_filter([
-            'where' => $this->where,
-            'orderBy' => $this->orderBy,
-        ]) + parent::toArray();
+        $result = parent::toArray();
+        $this->where === null or $result['where'] = $this->where;
+        $this->orderBy === null or $result['orderBy'] = $this->orderBy;
+        return $result;
     }
 }

--- a/src/Select/Options/HasManyLoadOptions.php
+++ b/src/Select/Options/HasManyLoadOptions.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Select\Options;
+
+use Cycle\ORM\Select\ScopeInterface;
+
+/**
+ * Load options for HasMany relations.
+ */
+final class HasManyLoadOptions extends JoinableLoadOptions
+{
+    public function __construct(
+        /**
+         * Defines how to load relation data: within the same query (JOIN) or using a separate query.
+         */
+        LoadMethod|JoinMethod|null $method = LoadMethod::OuterQuery,
+
+        /**
+         * Scope applied to the relation query.
+         * - `true` — use the default scope from the source (default)
+         * - `false` — disable scope
+         * - `ScopeInterface` — use a custom scope instance
+         */
+        ScopeInterface|bool $scope = true,
+
+        /**
+         * When true, loader column aliases will be minified in SQL output.
+         */
+        bool $minify = true,
+
+        /**
+         * Custom table alias for the relation in SQL.
+         * Calculated automatically if not set.
+         */
+        ?string $as = null,
+
+        /**
+         * Use an alias defined by another relation (typically from {@see \Cycle\ORM\Select::with()})
+         * as the data source instead of generating a new JOIN or query.
+         */
+        ?string $using = null,
+
+        /**
+         * Additional WHERE conditions for the relation query.
+         */
+        public ?array $where = null,
+
+        /**
+         * ORDER BY rules for the relation query.
+         */
+        public ?array $orderBy = null,
+    ) {
+        parent::__construct($method, $scope, $minify, $as, $using);
+    }
+}

--- a/src/Select/Options/HasOneLoadOptions.php
+++ b/src/Select/Options/HasOneLoadOptions.php
@@ -54,4 +54,12 @@ final class HasOneLoadOptions extends JoinableLoadOptions
     ) {
         parent::__construct($method, $scope, $minify, $as, $using);
     }
+
+    public function toArray(): array
+    {
+        return [
+            'where' => $this->where,
+            'orderBy' => $this->orderBy,
+        ] + parent::toArray();
+    }
 }

--- a/src/Select/Options/HasOneLoadOptions.php
+++ b/src/Select/Options/HasOneLoadOptions.php
@@ -53,8 +53,16 @@ final class HasOneLoadOptions extends JoinableLoadOptions
          * ORDER BY rules for the relation query.
          */
         public ?array $orderBy = null,
+
+        /**
+         * Override the table name for loading related entities.
+         * Useful for loading data from archive tables or alternative storage.
+         *
+         * @var non-empty-string|null
+         */
+        ?string $table = null,
     ) {
-        parent::__construct($method, $scope, $minify, $as, $using);
+        parent::__construct($method, $scope, $minify, $as, $using, $table);
     }
 
     public function toArray(): array

--- a/src/Select/Options/HasOneLoadOptions.php
+++ b/src/Select/Options/HasOneLoadOptions.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Select\Options;
+
+use Cycle\ORM\Select\ScopeInterface;
+
+/**
+ * Load options for HasOne relations.
+ */
+final class HasOneLoadOptions extends JoinableLoadOptions
+{
+    public function __construct(
+        /**
+         * Defines how to load relation data: within the same query (JOIN) or using a separate query.
+         */
+        LoadMethod|JoinMethod|null $method = LoadMethod::SingleQuery,
+
+        /**
+         * Scope applied to the relation query.
+         * - `true` — use the default scope from the source (default)
+         * - `false` — disable scope
+         * - `ScopeInterface` — use a custom scope instance
+         */
+        ScopeInterface|bool $scope = true,
+
+        /**
+         * When true, loader column aliases will be minified in SQL output.
+         */
+        bool $minify = true,
+
+        /**
+         * Custom table alias for the relation in SQL.
+         * Calculated automatically if not set.
+         */
+        ?string $as = null,
+
+        /**
+         * Use an alias defined by another relation (typically from {@see \Cycle\ORM\Select::with()})
+         * as the data source instead of generating a new JOIN or query.
+         */
+        ?string $using = null,
+
+        /**
+         * Additional WHERE conditions for the relation query.
+         */
+        public ?array $where = null,
+
+        /**
+         * ORDER BY rules for the relation query.
+         */
+        public ?array $orderBy = null,
+    ) {
+        parent::__construct($method, $scope, $minify, $as, $using);
+    }
+}

--- a/src/Select/Options/HasOneLoadOptions.php
+++ b/src/Select/Options/HasOneLoadOptions.php
@@ -59,9 +59,9 @@ final class HasOneLoadOptions extends JoinableLoadOptions
 
     public function toArray(): array
     {
-        return \array_filter([
-            'where' => $this->where,
-            'orderBy' => $this->orderBy,
-        ]) + parent::toArray();
+        $result = parent::toArray();
+        $this->where === null or $result['where'] = $this->where;
+        $this->orderBy === null or $result['orderBy'] = $this->orderBy;
+        return $result;
     }
 }

--- a/src/Select/Options/HasOneLoadOptions.php
+++ b/src/Select/Options/HasOneLoadOptions.php
@@ -27,6 +27,8 @@ final class HasOneLoadOptions extends JoinableLoadOptions
 
         /**
          * When true, loader column aliases will be minified in SQL output.
+         * @note Intended for debugging purposes. Use with caution: disabling minification
+         *       may cause column name conflicts between different relations.
          */
         bool $minify = true,
 
@@ -57,9 +59,9 @@ final class HasOneLoadOptions extends JoinableLoadOptions
 
     public function toArray(): array
     {
-        return [
+        return \array_filter([
             'where' => $this->where,
             'orderBy' => $this->orderBy,
-        ] + parent::toArray();
+        ]) + parent::toArray();
     }
 }

--- a/src/Select/Options/JoinMethod.php
+++ b/src/Select/Options/JoinMethod.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Select\Options;
+
+use Cycle\ORM\Select\JoinableLoader;
+
+enum JoinMethod: int
+{
+    /** INNER JOIN */
+    case InnerJoin = JoinableLoader::JOIN;
+
+    /** LEFT JOIN */
+    case LeftJoin = JoinableLoader::LEFT_JOIN;
+}

--- a/src/Select/Options/JoinMethod.php
+++ b/src/Select/Options/JoinMethod.php
@@ -8,9 +8,15 @@ use Cycle\ORM\Select\JoinableLoader;
 
 enum JoinMethod: int
 {
-    /** INNER JOIN */
-    case InnerJoin = JoinableLoader::JOIN;
+    /**
+     * INNER JOIN
+     * @see JoinableLoader::JOIN
+     */
+    case InnerJoin = 3;
 
-    /** LEFT JOIN */
-    case LeftJoin = JoinableLoader::LEFT_JOIN;
+    /**
+     * LEFT JOIN
+     * @see JoinableLoader::LEFT_JOIN
+     */
+    case LeftJoin = 4;
 }

--- a/src/Select/Options/JoinableLoadOptions.php
+++ b/src/Select/Options/JoinableLoadOptions.php
@@ -45,4 +45,13 @@ class JoinableLoadOptions extends LoadOptions
     ) {
         parent::__construct($scope, $minify);
     }
+
+    public function toArray(): array
+    {
+        return [
+            'method' => $this->method->value,
+            'as' => $this->as,
+            'using' => $this->using,
+        ] + parent::toArray();
+    }
 }

--- a/src/Select/Options/JoinableLoadOptions.php
+++ b/src/Select/Options/JoinableLoadOptions.php
@@ -28,6 +28,8 @@ class JoinableLoadOptions extends LoadOptions
 
         /**
          * When true, loader column aliases will be minified in SQL output.
+         * @note Intended for debugging purposes. Use with caution: disabling minification
+         *       may cause column name conflicts between different relations.
          */
         bool $minify = true,
 
@@ -48,10 +50,10 @@ class JoinableLoadOptions extends LoadOptions
 
     public function toArray(): array
     {
-        return [
-            'method' => $this->method->value,
+        return \array_filter([
+            'method' => $this->method?->value,
             'as' => $this->as,
             'using' => $this->using,
-        ] + parent::toArray();
+        ]) + parent::toArray();
     }
 }

--- a/src/Select/Options/JoinableLoadOptions.php
+++ b/src/Select/Options/JoinableLoadOptions.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Select\Options;
+
+use Cycle\ORM\Select\ScopeInterface;
+
+/**
+ * Load options for relations that support JoinableLoader features:
+ * loading method selection, table aliasing, and reusing joins.
+ */
+class JoinableLoadOptions extends LoadOptions
+{
+    public function __construct(
+        /**
+         * Defines how to load relation data: within the same query (JOIN) or using a separate query.
+         */
+        public LoadMethod|JoinMethod|null $method = null,
+
+        /**
+         * Scope applied to the relation query.
+         * - `true` — use the default scope from the source (default)
+         * - `false` — disable scope
+         * - `ScopeInterface` — use a custom scope instance
+         */
+        ScopeInterface|bool $scope = true,
+
+        /**
+         * When true, loader column aliases will be minified in SQL output.
+         */
+        bool $minify = true,
+
+        /**
+         * Custom table alias for the relation in SQL.
+         * Calculated automatically if not set.
+         */
+        public ?string $as = null,
+
+        /**
+         * Use an alias defined by another relation (typically from {@see \Cycle\ORM\Select::with()})
+         * as the data source instead of generating a new JOIN or query.
+         */
+        public ?string $using = null,
+    ) {
+        parent::__construct($scope, $minify);
+    }
+}

--- a/src/Select/Options/JoinableLoadOptions.php
+++ b/src/Select/Options/JoinableLoadOptions.php
@@ -50,10 +50,10 @@ class JoinableLoadOptions extends LoadOptions
 
     public function toArray(): array
     {
-        return \array_filter([
-            'method' => $this->method?->value,
-            'as' => $this->as,
-            'using' => $this->using,
-        ]) + parent::toArray();
+        $result = parent::toArray();
+        $this->method === null or $result['method'] = $this->method->value;
+        $this->as === null or $result['as'] = $this->as;
+        $this->using === null or $result['using'] = $this->using;
+        return $result;
     }
 }

--- a/src/Select/Options/JoinableLoadOptions.php
+++ b/src/Select/Options/JoinableLoadOptions.php
@@ -44,8 +44,15 @@ class JoinableLoadOptions extends LoadOptions
          * as the data source instead of generating a new JOIN or query.
          */
         public ?string $using = null,
+
+        /**
+         * Override the table name for loading related entities.
+         *
+         * @var non-empty-string|null
+         */
+        ?string $table = null,
     ) {
-        parent::__construct($scope, $minify);
+        parent::__construct($scope, $minify, $table);
     }
 
     public function toArray(): array

--- a/src/Select/Options/LoadMethod.php
+++ b/src/Select/Options/LoadMethod.php
@@ -8,9 +8,15 @@ use Cycle\ORM\Select;
 
 enum LoadMethod: int
 {
-    /** Load relation data within the same query using JOIN */
-    case SingleQuery = Select::SINGLE_QUERY;
+    /**
+     * Load relation data within the same query using JOIN
+     * @see Select::SINGLE_QUERY
+     */
+    case SingleQuery = 1;
 
-    /** Load related data using a separate query */
-    case OuterQuery = Select::OUTER_QUERY;
+    /**
+     * Load related data using a separate query
+     * @see Select::OUTER_QUERY
+     */
+    case OuterQuery = 2;
 }

--- a/src/Select/Options/LoadMethod.php
+++ b/src/Select/Options/LoadMethod.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Select\Options;
+
+use Cycle\ORM\Select;
+
+enum LoadMethod: int
+{
+    /** Load relation data within the same query using JOIN */
+    case SingleQuery = Select::SINGLE_QUERY;
+
+    /** Load related data using a separate query */
+    case OuterQuery = Select::OUTER_QUERY;
+}

--- a/src/Select/Options/LoadOptions.php
+++ b/src/Select/Options/LoadOptions.php
@@ -26,13 +26,23 @@ class LoadOptions
          *       may cause column name conflicts between different relations.
          */
         public bool $minify = true,
+
+        /**
+         * Override the table name for loading related entities.
+         * Useful for loading data from archive tables or alternative storage.
+         *
+         * @var non-empty-string|null
+         */
+        public ?string $table = null,
     ) {}
 
     public function toArray(): array
     {
-        return [
+        $result = [
             'scope' => $this->scope,
             'minify' => $this->minify,
         ];
+        $this->table === null or $result['table'] = $this->table;
+        return $result;
     }
 }

--- a/src/Select/Options/LoadOptions.php
+++ b/src/Select/Options/LoadOptions.php
@@ -22,6 +22,8 @@ class LoadOptions
 
         /**
          * When true, loader column aliases will be minified in SQL output.
+         * @note Intended for debugging purposes. Use with caution: disabling minification
+         *       may cause column name conflicts between different relations.
          */
         public bool $minify = true,
     ) {}

--- a/src/Select/Options/LoadOptions.php
+++ b/src/Select/Options/LoadOptions.php
@@ -25,4 +25,12 @@ class LoadOptions
          */
         public bool $minify = true,
     ) {}
+
+    public function toArray(): array
+    {
+        return [
+            'scope' => $this->scope,
+            'minify' => $this->minify,
+        ];
+    }
 }

--- a/src/Select/Options/LoadOptions.php
+++ b/src/Select/Options/LoadOptions.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Select\Options;
+
+use Cycle\ORM\Select\ScopeInterface;
+
+/**
+ * Base load options shared by all relation types.
+ */
+class LoadOptions
+{
+    public function __construct(
+        /**
+         * Scope applied to the relation query.
+         * - `true` — use the default scope from the source (default)
+         * - `false` — disable scope
+         * - `ScopeInterface` — use a custom scope instance
+         */
+        public ScopeInterface|bool $scope = true,
+
+        /**
+         * When true, loader column aliases will be minified in SQL output.
+         */
+        public bool $minify = true,
+    ) {}
+}

--- a/src/Select/Options/ManyToManyLoadOptions.php
+++ b/src/Select/Options/ManyToManyLoadOptions.php
@@ -59,4 +59,13 @@ final class ManyToManyLoadOptions extends JoinableLoadOptions
     ) {
         parent::__construct($method, $scope, $minify, $as, $using);
     }
+
+    public function toArray(): array
+    {
+        return [
+            'where' => $this->where,
+            'orderBy' => $this->orderBy,
+            'pivot' => $this->pivot,
+        ] + parent::toArray();
+    }
 }

--- a/src/Select/Options/ManyToManyLoadOptions.php
+++ b/src/Select/Options/ManyToManyLoadOptions.php
@@ -58,8 +58,16 @@ final class ManyToManyLoadOptions extends JoinableLoadOptions
          * Options for the pivot table loader.
          */
         public ?array $pivot = null,
+
+        /**
+         * Override the table name for loading related entities.
+         * Useful for loading data from archive tables or alternative storage.
+         *
+         * @var non-empty-string|null
+         */
+        ?string $table = null,
     ) {
-        parent::__construct($method, $scope, $minify, $as, $using);
+        parent::__construct($method, $scope, $minify, $as, $using, $table);
     }
 
     public function toArray(): array

--- a/src/Select/Options/ManyToManyLoadOptions.php
+++ b/src/Select/Options/ManyToManyLoadOptions.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Select\Options;
+
+use Cycle\ORM\Select\ScopeInterface;
+
+/**
+ * Load options for ManyToMany relations.
+ */
+final class ManyToManyLoadOptions extends JoinableLoadOptions
+{
+    public function __construct(
+        /**
+         * Defines how to load relation data: within the same query (JOIN) or using a separate query.
+         */
+        LoadMethod|JoinMethod|null $method = LoadMethod::OuterQuery,
+
+        /**
+         * Scope applied to the relation query.
+         * - `true` — use the default scope from the source (default)
+         * - `false` — disable scope
+         * - `ScopeInterface` — use a custom scope instance
+         */
+        ScopeInterface|bool $scope = true,
+
+        /**
+         * When true, loader column aliases will be minified in SQL output.
+         */
+        bool $minify = true,
+
+        /**
+         * Custom table alias for the relation in SQL.
+         * Calculated automatically if not set.
+         */
+        ?string $as = null,
+
+        /**
+         * Use an alias defined by another relation (typically from {@see \Cycle\ORM\Select::with()})
+         * as the data source instead of generating a new JOIN or query.
+         */
+        ?string $using = null,
+
+        /**
+         * Additional WHERE conditions for the relation query.
+         */
+        public ?array $where = null,
+
+        /**
+         * ORDER BY rules for the relation query.
+         */
+        public ?array $orderBy = null,
+
+        /**
+         * Options for the pivot table loader.
+         */
+        public ?array $pivot = null,
+    ) {
+        parent::__construct($method, $scope, $minify, $as, $using);
+    }
+}

--- a/src/Select/Options/ManyToManyLoadOptions.php
+++ b/src/Select/Options/ManyToManyLoadOptions.php
@@ -64,10 +64,10 @@ final class ManyToManyLoadOptions extends JoinableLoadOptions
 
     public function toArray(): array
     {
-        return \array_filter([
-            'where' => $this->where,
-            'orderBy' => $this->orderBy,
-            'pivot' => $this->pivot,
-        ]) + parent::toArray();
+        $result = parent::toArray();
+        $this->where === null or $result['where'] = $this->where;
+        $this->orderBy === null or $result['orderBy'] = $this->orderBy;
+        $this->pivot === null or $result['pivot'] = $this->pivot;
+        return $result;
     }
 }

--- a/src/Select/Options/ManyToManyLoadOptions.php
+++ b/src/Select/Options/ManyToManyLoadOptions.php
@@ -27,6 +27,8 @@ final class ManyToManyLoadOptions extends JoinableLoadOptions
 
         /**
          * When true, loader column aliases will be minified in SQL output.
+         * @note Intended for debugging purposes. Use with caution: disabling minification
+         *       may cause column name conflicts between different relations.
          */
         bool $minify = true,
 
@@ -62,10 +64,10 @@ final class ManyToManyLoadOptions extends JoinableLoadOptions
 
     public function toArray(): array
     {
-        return [
+        return \array_filter([
             'where' => $this->where,
             'orderBy' => $this->orderBy,
             'pivot' => $this->pivot,
-        ] + parent::toArray();
+        ]) + parent::toArray();
     }
 }

--- a/src/Select/Options/MorphedHasManyLoadOptions.php
+++ b/src/Select/Options/MorphedHasManyLoadOptions.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Select\Options;
+
+use Cycle\ORM\Select\ScopeInterface;
+
+/**
+ * Load options for MorphedHasMany relations.
+ *
+ * Shares the same base options as HasMany since MorphedHasManyLoader extends HasManyLoader.
+ * Exists as a separate class to allow adding morphed-specific options in the future.
+ */
+final class MorphedHasManyLoadOptions extends JoinableLoadOptions
+{
+    public function __construct(
+        /**
+         * Defines how to load relation data: within the same query (JOIN) or using a separate query.
+         */
+        LoadMethod|JoinMethod|null $method = LoadMethod::OuterQuery,
+
+        /**
+         * Scope applied to the relation query.
+         * - `true` — use the default scope from the source (default)
+         * - `false` — disable scope
+         * - `ScopeInterface` — use a custom scope instance
+         */
+        ScopeInterface|bool $scope = true,
+
+        /**
+         * When true, loader column aliases will be minified in SQL output.
+         */
+        bool $minify = true,
+
+        /**
+         * Custom table alias for the relation in SQL.
+         * Calculated automatically if not set.
+         */
+        ?string $as = null,
+
+        /**
+         * Use an alias defined by another relation (typically from {@see \Cycle\ORM\Select::with()})
+         * as the data source instead of generating a new JOIN or query.
+         */
+        ?string $using = null,
+
+        /**
+         * Additional WHERE conditions for the relation query.
+         */
+        public ?array $where = null,
+
+        /**
+         * ORDER BY rules for the relation query.
+         */
+        public ?array $orderBy = null,
+    ) {
+        parent::__construct($method, $scope, $minify, $as, $using);
+    }
+}

--- a/src/Select/Options/MorphedHasManyLoadOptions.php
+++ b/src/Select/Options/MorphedHasManyLoadOptions.php
@@ -30,6 +30,8 @@ final class MorphedHasManyLoadOptions extends JoinableLoadOptions
 
         /**
          * When true, loader column aliases will be minified in SQL output.
+         * @note Intended for debugging purposes. Use with caution: disabling minification
+         *       may cause column name conflicts between different relations.
          */
         bool $minify = true,
 
@@ -60,9 +62,9 @@ final class MorphedHasManyLoadOptions extends JoinableLoadOptions
 
     public function toArray(): array
     {
-        return [
+        return \array_filter([
             'where' => $this->where,
             'orderBy' => $this->orderBy,
-        ] + parent::toArray();
+        ]) + parent::toArray();
     }
 }

--- a/src/Select/Options/MorphedHasManyLoadOptions.php
+++ b/src/Select/Options/MorphedHasManyLoadOptions.php
@@ -56,8 +56,16 @@ final class MorphedHasManyLoadOptions extends JoinableLoadOptions
          * ORDER BY rules for the relation query.
          */
         public ?array $orderBy = null,
+
+        /**
+         * Override the table name for loading related entities.
+         * Useful for loading data from archive tables or alternative storage.
+         *
+         * @var non-empty-string|null
+         */
+        ?string $table = null,
     ) {
-        parent::__construct($method, $scope, $minify, $as, $using);
+        parent::__construct($method, $scope, $minify, $as, $using, $table);
     }
 
     public function toArray(): array

--- a/src/Select/Options/MorphedHasManyLoadOptions.php
+++ b/src/Select/Options/MorphedHasManyLoadOptions.php
@@ -57,4 +57,12 @@ final class MorphedHasManyLoadOptions extends JoinableLoadOptions
     ) {
         parent::__construct($method, $scope, $minify, $as, $using);
     }
+
+    public function toArray(): array
+    {
+        return [
+            'where' => $this->where,
+            'orderBy' => $this->orderBy,
+        ] + parent::toArray();
+    }
 }

--- a/src/Select/Options/MorphedHasManyLoadOptions.php
+++ b/src/Select/Options/MorphedHasManyLoadOptions.php
@@ -62,9 +62,9 @@ final class MorphedHasManyLoadOptions extends JoinableLoadOptions
 
     public function toArray(): array
     {
-        return \array_filter([
-            'where' => $this->where,
-            'orderBy' => $this->orderBy,
-        ]) + parent::toArray();
+        $result = parent::toArray();
+        $this->where === null or $result['where'] = $this->where;
+        $this->orderBy === null or $result['orderBy'] = $this->orderBy;
+        return $result;
     }
 }

--- a/src/Select/Options/MorphedHasOneLoadOptions.php
+++ b/src/Select/Options/MorphedHasOneLoadOptions.php
@@ -30,6 +30,8 @@ final class MorphedHasOneLoadOptions extends JoinableLoadOptions
 
         /**
          * When true, loader column aliases will be minified in SQL output.
+         * @note Intended for debugging purposes. Use with caution: disabling minification
+         *       may cause column name conflicts between different relations.
          */
         bool $minify = true,
 
@@ -60,9 +62,9 @@ final class MorphedHasOneLoadOptions extends JoinableLoadOptions
 
     public function toArray(): array
     {
-        return [
+        return \array_filter([
             'where' => $this->where,
             'orderBy' => $this->orderBy,
-        ] + parent::toArray();
+        ]) + parent::toArray();
     }
 }

--- a/src/Select/Options/MorphedHasOneLoadOptions.php
+++ b/src/Select/Options/MorphedHasOneLoadOptions.php
@@ -56,8 +56,16 @@ final class MorphedHasOneLoadOptions extends JoinableLoadOptions
          * ORDER BY rules for the relation query.
          */
         public ?array $orderBy = null,
+
+        /**
+         * Override the table name for loading related entities.
+         * Useful for loading data from archive tables or alternative storage.
+         *
+         * @var non-empty-string|null
+         */
+        ?string $table = null,
     ) {
-        parent::__construct($method, $scope, $minify, $as, $using);
+        parent::__construct($method, $scope, $minify, $as, $using, $table);
     }
 
     public function toArray(): array

--- a/src/Select/Options/MorphedHasOneLoadOptions.php
+++ b/src/Select/Options/MorphedHasOneLoadOptions.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Select\Options;
+
+use Cycle\ORM\Select\ScopeInterface;
+
+/**
+ * Load options for MorphedHasOne relations.
+ *
+ * Shares the same base options as HasOne since MorphedHasOneLoader extends HasOneLoader.
+ * Exists as a separate class to allow adding morphed-specific options in the future.
+ */
+final class MorphedHasOneLoadOptions extends JoinableLoadOptions
+{
+    public function __construct(
+        /**
+         * Defines how to load relation data: within the same query (JOIN) or using a separate query.
+         */
+        LoadMethod|JoinMethod|null $method = LoadMethod::SingleQuery,
+
+        /**
+         * Scope applied to the relation query.
+         * - `true` — use the default scope from the source (default)
+         * - `false` — disable scope
+         * - `ScopeInterface` — use a custom scope instance
+         */
+        ScopeInterface|bool $scope = true,
+
+        /**
+         * When true, loader column aliases will be minified in SQL output.
+         */
+        bool $minify = true,
+
+        /**
+         * Custom table alias for the relation in SQL.
+         * Calculated automatically if not set.
+         */
+        ?string $as = null,
+
+        /**
+         * Use an alias defined by another relation (typically from {@see \Cycle\ORM\Select::with()})
+         * as the data source instead of generating a new JOIN or query.
+         */
+        ?string $using = null,
+
+        /**
+         * Additional WHERE conditions for the relation query.
+         */
+        public ?array $where = null,
+
+        /**
+         * ORDER BY rules for the relation query.
+         */
+        public ?array $orderBy = null,
+    ) {
+        parent::__construct($method, $scope, $minify, $as, $using);
+    }
+}

--- a/src/Select/Options/MorphedHasOneLoadOptions.php
+++ b/src/Select/Options/MorphedHasOneLoadOptions.php
@@ -62,9 +62,9 @@ final class MorphedHasOneLoadOptions extends JoinableLoadOptions
 
     public function toArray(): array
     {
-        return \array_filter([
-            'where' => $this->where,
-            'orderBy' => $this->orderBy,
-        ]) + parent::toArray();
+        $result = parent::toArray();
+        $this->where === null or $result['where'] = $this->where;
+        $this->orderBy === null or $result['orderBy'] = $this->orderBy;
+        return $result;
     }
 }

--- a/src/Select/Options/MorphedHasOneLoadOptions.php
+++ b/src/Select/Options/MorphedHasOneLoadOptions.php
@@ -57,4 +57,12 @@ final class MorphedHasOneLoadOptions extends JoinableLoadOptions
     ) {
         parent::__construct($method, $scope, $minify, $as, $using);
     }
+
+    public function toArray(): array
+    {
+        return [
+            'where' => $this->where,
+            'orderBy' => $this->orderBy,
+        ] + parent::toArray();
+    }
 }

--- a/src/Select/RootLoader.php
+++ b/src/Select/RootLoader.php
@@ -48,7 +48,7 @@ final class RootLoader extends AbstractLoader
     ) {
         parent::__construct($ormSchema, $sourceProvider, $factory, $target);
         $this->query = $this->source->getDatabase()->select()->from(
-            \sprintf('%s AS %s', $this->source->getTable(), $this->getAlias()),
+            \sprintf('%s AS %s', $this->table, $this->getAlias()),
         );
         $this->columns = $this->normalizeColumns($this->define(SchemaInterface::COLUMNS));
 

--- a/src/Select/SourceInterface.php
+++ b/src/Select/SourceInterface.php
@@ -18,6 +18,7 @@ interface SourceInterface
 
     /**
      * Get table associated with the entity.
+     * @return non-empty-string
      */
     public function getTable(): string;
 

--- a/src/Select/Traits/ChainTrait.php
+++ b/src/Select/Traits/ChainTrait.php
@@ -7,6 +7,7 @@ namespace Cycle\ORM\Select\Traits;
 use Cycle\ORM\Exception\LoaderException;
 use Cycle\ORM\Select\AbstractLoader;
 use Cycle\ORM\Select\LoaderInterface;
+use Cycle\ORM\Select\Options\LoadOptions;
 
 /**
  * @internal
@@ -15,7 +16,7 @@ trait ChainTrait
 {
     abstract public function loadRelation(
         string|LoaderInterface $relation,
-        array $options,
+        LoadOptions|array $options,
         bool $join = false,
         bool $load = false,
     ): LoaderInterface;

--- a/tests/ORM/Functional/Driver/Common/BaseTest.php
+++ b/tests/ORM/Functional/Driver/Common/BaseTest.php
@@ -256,9 +256,7 @@ abstract class BaseTest extends TestCase
         $r = new \ReflectionClass(Node::class);
 
         $rel = $r->getProperty('relations');
-        if (PHP_VERSION_ID < 80100) {
-            $rel->setAccessible(true);
-        }
+        PHP_VERSION_ID < 80100 and $rel->setAccessible(true);
 
         $heap = $orm->getHeap();
         foreach ($heap as $entity) {

--- a/tests/ORM/Functional/Driver/Common/Mapper/ProxyEntityMapper/EntityWithRelationCreationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Mapper/ProxyEntityMapper/EntityWithRelationCreationTest.php
@@ -22,7 +22,7 @@ class EntityWithRelationCreationTest extends BaseMapperTest
         $refl = new \ReflectionClass(EntityWithRelationCreationAbstractUser::class);
 
         $profileProperty = $refl->getProperty('profile');
-        $profileProperty->setAccessible(true);
+        PHP_VERSION_ID < 80100 and $profileProperty->setAccessible(true);
 
         $this->assertFalse($profileProperty->isInitialized($emptyObject));
         $this->assertEquals(123, $emptyObject->id);

--- a/tests/ORM/Functional/Driver/Common/Relation/BelongsTo/BelongsToLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/BelongsTo/BelongsToLoadOptionsTest.php
@@ -149,10 +149,10 @@ abstract class BelongsToLoadOptionsTest extends BaseTest
         ]);
 
         $this->getDatabase()->table('user_archive')->insertMultiple(
-            ['id', 'email', 'balance'],
+            ['email', 'balance'],
             [
-                [1, 'archived@world.com', 999],
-                [2, 'archived2@world.com', 888],
+                ['archived@world.com', 999],
+                ['archived2@world.com', 888],
             ],
         );
 

--- a/tests/ORM/Functional/Driver/Common/Relation/BelongsTo/BelongsToLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/BelongsTo/BelongsToLoadOptionsTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Relation\BelongsTo;
+
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\Relation;
+use Cycle\ORM\Schema;
+use Cycle\ORM\Select;
+use Cycle\ORM\Select\Options\BelongsToLoadOptions;
+use Cycle\ORM\Select\Options\LoadMethod;
+use Cycle\ORM\Tests\Fixtures\Profile;
+use Cycle\ORM\Tests\Fixtures\User;
+use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
+use Cycle\ORM\Tests\Traits\TableTrait;
+
+abstract class BelongsToLoadOptionsTest extends BaseTest
+{
+    use TableTrait;
+
+    public function testLoadWithSingleQueryMethod(): void
+    {
+        $selector = new Select($this->orm, Profile::class);
+        $selector->load('user', new BelongsToLoadOptions(
+            method: LoadMethod::SingleQuery,
+        ))->orderBy('profile.id');
+
+        $this->assertEquals([
+            [
+                'id' => 1,
+                'user_id' => 1,
+                'image' => 'image.png',
+                'user' => [
+                    'id' => 1,
+                    'email' => 'hello@world.com',
+                    'balance' => 100.0,
+                ],
+            ],
+            [
+                'id' => 2,
+                'user_id' => 2,
+                'image' => 'second.png',
+                'user' => [
+                    'id' => 2,
+                    'email' => 'another@world.com',
+                    'balance' => 200.0,
+                ],
+            ],
+            [
+                'id' => 3,
+                'user_id' => 2,
+                'image' => 'third.png',
+                'user' => [
+                    'id' => 2,
+                    'email' => 'another@world.com',
+                    'balance' => 200.0,
+                ],
+            ],
+        ], $selector->fetchData());
+    }
+
+    public function testLoadWithOuterQueryMethod(): void
+    {
+        $selector = new Select($this->orm, Profile::class);
+        $selector->load('user', new BelongsToLoadOptions(
+            method: LoadMethod::OuterQuery,
+        ))->orderBy('profile.id');
+
+        $this->assertEquals([
+            [
+                'id' => 1,
+                'user_id' => 1,
+                'image' => 'image.png',
+                'user' => [
+                    'id' => 1,
+                    'email' => 'hello@world.com',
+                    'balance' => 100.0,
+                ],
+            ],
+            [
+                'id' => 2,
+                'user_id' => 2,
+                'image' => 'second.png',
+                'user' => [
+                    'id' => 2,
+                    'email' => 'another@world.com',
+                    'balance' => 200.0,
+                ],
+            ],
+            [
+                'id' => 3,
+                'user_id' => 2,
+                'image' => 'third.png',
+                'user' => [
+                    'id' => 2,
+                    'email' => 'another@world.com',
+                    'balance' => 200.0,
+                ],
+            ],
+        ], $selector->fetchData());
+    }
+
+    public function testLoadWithUsing(): void
+    {
+        $selector = new Select($this->orm, Profile::class);
+        $selector
+            ->with('user', ['as' => 'user'])
+            ->load('user', new BelongsToLoadOptions(
+                using: 'user',
+            ))
+            ->orderBy('user.id', 'DESC')
+            ->orderBy('id', 'DESC')
+            ->limit(1);
+
+        $this->assertEquals([
+            [
+                'id' => 3,
+                'user_id' => 2,
+                'image' => 'third.png',
+                'user' => [
+                    'id' => 2,
+                    'email' => 'another@world.com',
+                    'balance' => 200.0,
+                ],
+            ],
+        ], $selector->fetchData());
+    }
+
+    public function testLoadWithDefaultOptions(): void
+    {
+        $selector = new Select($this->orm, Profile::class);
+        $selector->load('user', new BelongsToLoadOptions())->orderBy('profile.id');
+
+        $res = $selector->fetchAll();
+
+        $this->assertCount(3, $res);
+        $this->assertSame('hello@world.com', $res[0]->user->email);
+        $this->assertSame('another@world.com', $res[1]->user->email);
+        $this->assertSame('another@world.com', $res[2]->user->email);
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->makeTable('user', [
+            'id' => 'primary',
+            'email' => 'string',
+            'balance' => 'float',
+        ]);
+
+        $this->getDatabase()->table('user')->insertMultiple(
+            ['email', 'balance'],
+            [
+                ['hello@world.com', 100],
+                ['another@world.com', 200],
+            ],
+        );
+
+        $this->makeTable('profile', [
+            'id' => 'primary',
+            'user_id' => 'integer,nullable',
+            'image' => 'string',
+        ]);
+
+        $this->getDatabase()->table('profile')->insertMultiple(
+            ['user_id', 'image'],
+            [
+                [1, 'image.png'],
+                [2, 'second.png'],
+                [2, 'third.png'],
+            ],
+        );
+
+        $this->makeFK('profile', 'user_id', 'user', 'id');
+
+        $this->orm = $this->withSchema(new Schema([
+            User::class => [
+                Schema::ROLE => 'user',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'user',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'email', 'balance'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [],
+            ],
+            Profile::class => [
+                Schema::ROLE => 'profile',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'profile',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'user_id', 'image'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [
+                    'user' => [
+                        Relation::TYPE => Relation::BELONGS_TO,
+                        Relation::TARGET => User::class,
+                        Relation::SCHEMA => [
+                            Relation::CASCADE => true,
+                            Relation::INNER_KEY => 'user_id',
+                            Relation::OUTER_KEY => 'id',
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Relation/BelongsTo/BelongsToLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/BelongsTo/BelongsToLoadOptionsTest.php
@@ -140,6 +140,32 @@ abstract class BelongsToLoadOptionsTest extends BaseTest
         $this->assertSame('another@world.com', $res[2]->user->email);
     }
 
+    public function testLoadFromArchiveTable(): void
+    {
+        $this->makeTable('user_archive', [
+            'id' => 'primary',
+            'email' => 'string',
+            'balance' => 'float',
+        ]);
+
+        $this->getDatabase()->table('user_archive')->insertMultiple(
+            ['id', 'email', 'balance'],
+            [
+                [1, 'archived@world.com', 999],
+                [2, 'archived2@world.com', 888],
+            ],
+        );
+
+        $res = (new Select($this->orm, Profile::class))->load('user', new BelongsToLoadOptions(
+            table: 'user_archive',
+        ))->orderBy('profile.id')->fetchAll();
+
+        $this->assertCount(3, $res);
+        $this->assertSame('archived@world.com', $res[0]->user->email);
+        $this->assertSame('archived2@world.com', $res[1]->user->email);
+        $this->assertSame('archived2@world.com', $res[2]->user->email);
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/ORM/Functional/Driver/Common/Relation/HasMany/HasManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/HasMany/HasManyLoadOptionsTest.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Relation\HasMany;
+
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\ORMInterface;
+use Cycle\ORM\Relation;
+use Cycle\ORM\Schema;
+use Cycle\ORM\Select;
+use Cycle\ORM\Select\Options\HasManyLoadOptions;
+use Cycle\ORM\Select\Options\LoadMethod;
+use Cycle\ORM\Tests\Fixtures\Comment;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
+use Cycle\ORM\Tests\Fixtures\User;
+use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
+use Cycle\ORM\Tests\Traits\TableTrait;
+
+abstract class HasManyLoadOptionsTest extends BaseTest
+{
+    use TableTrait;
+
+    public function testLoadWithSingleQueryMethod(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'ASC']),
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('comments', new HasManyLoadOptions(
+            method: LoadMethod::SingleQuery,
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertCount(4, $a->comments);
+        $this->assertCount(3, $b->comments);
+
+        $this->assertSame('msg 1', $a->comments[0]->message);
+        $this->assertSame('msg 4', $a->comments[3]->message);
+        $this->assertSame('msg 2.1', $b->comments[0]->message);
+        $this->assertSame('msg 2.3', $b->comments[2]->message);
+    }
+
+    public function testLoadWithOuterQueryMethod(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'ASC']),
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('comments', new HasManyLoadOptions(
+            method: LoadMethod::OuterQuery,
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertCount(4, $a->comments);
+        $this->assertCount(3, $b->comments);
+
+        $this->assertSame('msg 1', $a->comments[0]->message);
+        $this->assertSame('msg 2.1', $b->comments[0]->message);
+    }
+
+    public function testLoadWithCustomWhere(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'ASC']),
+            Relation::SCHEMA => [Relation::WHERE => ['@.level' => ['>=' => 2]]],
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->orderBy('user.id')->load('comments', new HasManyLoadOptions(
+            where: ['@.level' => 1],
+        ))->fetchAll();
+
+        $this->assertCount(1, $a->comments);
+        $this->assertCount(1, $b->comments);
+
+        $this->assertSame('msg 1', $a->comments[0]->message);
+        $this->assertSame('msg 2.1', $b->comments[0]->message);
+    }
+
+    public function testLoadWithCustomWhereAndSingleQuery(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'ASC']),
+            Relation::SCHEMA => [Relation::WHERE => ['@.level' => ['>=' => 2]]],
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->orderBy('user.id')->load('comments', new HasManyLoadOptions(
+            method: LoadMethod::SingleQuery,
+            where: ['@.level' => 1],
+        ))->fetchAll();
+
+        $this->assertCount(1, $a->comments);
+        $this->assertCount(1, $b->comments);
+
+        $this->assertSame('msg 1', $a->comments[0]->message);
+        $this->assertSame('msg 2.1', $b->comments[0]->message);
+    }
+
+    public function testLoadWithOrderBy(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Relation::SCHEMA => [
+                Relation::ORDER_BY => ['@.level' => 'DESC'],
+            ],
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('comments', new HasManyLoadOptions(
+            orderBy: ['@.level' => 'ASC'],
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertCount(4, $a->comments);
+        $this->assertCount(3, $b->comments);
+
+        $this->assertSame('msg 1', $a->comments[0]->message);
+        $this->assertSame('msg 4', $a->comments[3]->message);
+        $this->assertSame('msg 2.1', $b->comments[0]->message);
+        $this->assertSame('msg 2.3', $b->comments[2]->message);
+    }
+
+    public function testLoadWithScopeDisabled(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Schema::SCOPE => new Select\QueryScope(['@.level' => 4]),
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('comments', new HasManyLoadOptions(
+            scope: false,
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertCount(4, $a->comments);
+        $this->assertCount(3, $b->comments);
+    }
+
+    public function testLoadWithCustomScope(): void
+    {
+        $this->orm = $this->withCommentsSchema([]);
+
+        $res = (new Select($this->orm, User::class))->load('comments', new HasManyLoadOptions(
+            scope: new Select\QueryScope(['@.level' => ['>=' => 3]], ['@.level' => 'DESC']),
+        ))->orderBy('user.id')->fetchAll();
+
+        [$a, $b] = $res;
+
+        $this->assertCount(2, $a->comments);
+        $this->assertCount(1, $b->comments);
+
+        $this->assertSame('msg 4', $a->comments[0]->message);
+        $this->assertSame('msg 3', $a->comments[1]->message);
+        $this->assertSame('msg 2.3', $b->comments[0]->message);
+    }
+
+    public function testLoadWithCustomScopeAndSingleQuery(): void
+    {
+        $this->orm = $this->withCommentsSchema([]);
+
+        $res = (new Select($this->orm, User::class))->load('comments', new HasManyLoadOptions(
+            method: LoadMethod::SingleQuery,
+            scope: new Select\QueryScope(['@.level' => ['>=' => 3]], ['@.level' => 'DESC']),
+        ))->orderBy('user.id')->fetchAll();
+
+        [$a, $b] = $res;
+
+        $this->assertCount(2, $a->comments);
+        $this->assertCount(1, $b->comments);
+
+        $this->assertSame('msg 4', $a->comments[0]->message);
+        $this->assertSame('msg 3', $a->comments[1]->message);
+        $this->assertSame('msg 2.3', $b->comments[0]->message);
+    }
+
+    public function testLoadWithSingleQueryAndScopeAndWhere(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Relation::SCHEMA => [Relation::WHERE => ['@.level' => ['>=' => 3]]],
+            Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'DESC']),
+        ]);
+
+        // Array-based call as reference
+        $expected = (new Select($this->orm, User::class))->load('comments', [
+            'method' => Select\JoinableLoader::INLOAD,
+        ])->orderBy('user.id', 'DESC')->fetchAll();
+
+        // DTO-based call
+        $res = (new Select($this->orm, User::class))->load('comments', new HasManyLoadOptions(
+            method: LoadMethod::SingleQuery,
+        ))->orderBy('user.id', 'DESC')->fetchAll();
+
+        $this->assertCount(\count($expected), $res);
+        $this->assertSame($expected[0]->email, $res[0]->email);
+        $this->assertSame($expected[1]->email, $res[1]->email);
+
+        $this->assertCount(\count($expected[1]->comments), $res[1]->comments);
+        $this->assertCount(\count($expected[0]->comments), $res[0]->comments);
+
+        foreach ($expected[1]->comments as $i => $comment) {
+            $this->assertSame($comment->message, $res[1]->comments[$i]->message);
+        }
+        foreach ($expected[0]->comments as $i => $comment) {
+            $this->assertSame($comment->message, $res[0]->comments[$i]->message);
+        }
+    }
+
+    public function testLoadWithDefaultOptions(): void
+    {
+        $this->orm = $this->withCommentsSchema([]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('comments', new HasManyLoadOptions())
+            ->orderBy('user.id')->fetchAll();
+
+        $this->assertCount(4, $a->comments);
+        $this->assertCount(3, $b->comments);
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->makeTable('user', [
+            'id' => 'primary',
+            'email' => 'string',
+            'balance' => 'float',
+        ]);
+
+        $this->getDatabase()->table('user')->insertMultiple(
+            ['email', 'balance'],
+            [
+                ['hello@world.com', 100],
+                ['another@world.com', 200],
+            ],
+        );
+
+        $this->makeTable('comment', [
+            'id' => 'primary',
+            'user_id' => 'integer',
+            'level' => 'integer',
+            'message' => 'string',
+        ]);
+
+        $this->makeFK('comment', 'user_id', 'user', 'id');
+
+        $this->getDatabase()->table('comment')->insertMultiple(
+            ['user_id', 'level', 'message'],
+            [
+                [1, 1, 'msg 1'],
+                [1, 2, 'msg 2'],
+                [1, 3, 'msg 3'],
+                [1, 4, 'msg 4'],
+                [2, 1, 'msg 2.1'],
+                [2, 2, 'msg 2.2'],
+                [2, 3, 'msg 2.3'],
+            ],
+        );
+    }
+
+    protected function withCommentsSchema(array $relationSchema): ORMInterface
+    {
+        $eSchema = [];
+        if (isset($relationSchema[Schema::SCOPE])) {
+            $eSchema[Schema::SCOPE] = $relationSchema[Schema::SCOPE];
+        }
+
+        $rSchema = $relationSchema[Relation::SCHEMA] ?? [];
+
+        return $this->orm->withSchema(new Schema([
+            User::class => [
+                Schema::ROLE => 'user',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'user',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'email', 'balance'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [
+                    'comments' => [
+                        Relation::TYPE => Relation::HAS_MANY,
+                        Relation::TARGET => Comment::class,
+                        Relation::SCHEMA => [
+                            Relation::CASCADE => true,
+                            Relation::INNER_KEY => 'id',
+                            Relation::OUTER_KEY => 'user_id',
+                        ] + $rSchema,
+                    ],
+                ],
+                Schema::SCOPE => SortByIDScope::class,
+            ],
+            Comment::class => [
+                Schema::ROLE => 'comment',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'comment',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'user_id', 'level', 'message'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [],
+            ] + $eSchema,
+        ]));
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Relation/HasMany/HasManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/HasMany/HasManyLoadOptionsTest.php
@@ -27,17 +27,26 @@ abstract class HasManyLoadOptionsTest extends BaseTest
             Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'ASC']),
         ]);
 
-        [$a, $b] = (new Select($this->orm, User::class))->load('comments', new HasManyLoadOptions(
+        // Array-based call as reference
+        $expected = (new Select($this->orm, User::class))->load('comments', [
+            'method' => Select\JoinableLoader::INLOAD,
+        ])->orderBy('user.id')->fetchAll();
+
+        // DTO-based call
+        $res = (new Select($this->orm, User::class))->load('comments', new HasManyLoadOptions(
             method: LoadMethod::SingleQuery,
         ))->orderBy('user.id')->fetchAll();
 
-        $this->assertCount(4, $a->comments);
-        $this->assertCount(3, $b->comments);
+        $this->assertCount(\count($expected), $res);
+        $this->assertCount(\count($expected[0]->comments), $res[0]->comments);
+        $this->assertCount(\count($expected[1]->comments), $res[1]->comments);
 
-        $this->assertSame('msg 1', $a->comments[0]->message);
-        $this->assertSame('msg 4', $a->comments[3]->message);
-        $this->assertSame('msg 2.1', $b->comments[0]->message);
-        $this->assertSame('msg 2.3', $b->comments[2]->message);
+        foreach ($expected[0]->comments as $i => $comment) {
+            $this->assertSame($comment->message, $res[0]->comments[$i]->message);
+        }
+        foreach ($expected[1]->comments as $i => $comment) {
+            $this->assertSame($comment->message, $res[1]->comments[$i]->message);
+        }
     }
 
     public function testLoadWithOuterQueryMethod(): void
@@ -151,19 +160,28 @@ abstract class HasManyLoadOptionsTest extends BaseTest
     {
         $this->orm = $this->withCommentsSchema([]);
 
+        // Array-based call as reference
+        $expected = (new Select($this->orm, User::class))->load('comments', [
+            'method' => Select\JoinableLoader::INLOAD,
+            'scope' => new Select\QueryScope(['@.level' => ['>=' => 3]], ['@.level' => 'DESC']),
+        ])->orderBy('user.id')->fetchAll();
+
+        // DTO-based call
         $res = (new Select($this->orm, User::class))->load('comments', new HasManyLoadOptions(
             method: LoadMethod::SingleQuery,
             scope: new Select\QueryScope(['@.level' => ['>=' => 3]], ['@.level' => 'DESC']),
         ))->orderBy('user.id')->fetchAll();
 
-        [$a, $b] = $res;
+        $this->assertCount(\count($expected), $res);
+        $this->assertCount(\count($expected[0]->comments), $res[0]->comments);
+        $this->assertCount(\count($expected[1]->comments), $res[1]->comments);
 
-        $this->assertCount(2, $a->comments);
-        $this->assertCount(1, $b->comments);
-
-        $this->assertSame('msg 4', $a->comments[0]->message);
-        $this->assertSame('msg 3', $a->comments[1]->message);
-        $this->assertSame('msg 2.3', $b->comments[0]->message);
+        foreach ($expected[0]->comments as $i => $comment) {
+            $this->assertSame($comment->message, $res[0]->comments[$i]->message);
+        }
+        foreach ($expected[1]->comments as $i => $comment) {
+            $this->assertSame($comment->message, $res[1]->comments[$i]->message);
+        }
     }
 
     public function testLoadWithSingleQueryAndScopeAndWhere(): void

--- a/tests/ORM/Functional/Driver/Common/Relation/HasMany/HasManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/HasMany/HasManyLoadOptionsTest.php
@@ -227,6 +227,42 @@ abstract class HasManyLoadOptionsTest extends BaseTest
         $this->assertCount(3, $b->comments);
     }
 
+    public function testLoadFromArchiveTable(): void
+    {
+        // Create archive table with the same structure as comment
+        $this->makeTable('comment_archive', [
+            'id' => 'primary',
+            'user_id' => 'integer',
+            'level' => 'integer',
+            'message' => 'string',
+        ]);
+
+        $this->getDatabase()->table('comment_archive')->insertMultiple(
+            ['user_id', 'level', 'message'],
+            [
+                [1, 10, 'archived 1'],
+                [1, 20, 'archived 2'],
+                [2, 10, 'archived 2.1'],
+            ],
+        );
+
+        $this->orm = $this->withCommentsSchema([]);
+
+        // Load from archive table instead of default "comment" table
+        [$a, $b] = (new Select($this->orm, User::class))->load('comments', new HasManyLoadOptions(
+            table: 'comment_archive',
+            orderBy: ['@.level' => 'ASC'],
+        ))->orderBy('user.id')->fetchAll();
+
+        // Data should come from archive, not from the main comment table
+        $this->assertCount(2, $a->comments);
+        $this->assertCount(1, $b->comments);
+
+        $this->assertSame('archived 1', $a->comments[0]->message);
+        $this->assertSame('archived 2', $a->comments[1]->message);
+        $this->assertSame('archived 2.1', $b->comments[0]->message);
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/ORM/Functional/Driver/Common/Relation/HasOne/HasOneLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/HasOne/HasOneLoadOptionsTest.php
@@ -154,6 +154,33 @@ abstract class HasOneLoadOptionsTest extends BaseTest
         $this->assertSame('msg 2.1', $b->firstComment->message);
     }
 
+    public function testLoadFromArchiveTable(): void
+    {
+        $this->makeTable('comment_archive', [
+            'id' => 'primary',
+            'user_id' => 'integer',
+            'level' => 'integer',
+            'message' => 'string',
+        ]);
+
+        $this->getDatabase()->table('comment_archive')->insertMultiple(
+            ['user_id', 'level', 'message'],
+            [
+                [1, 1, 'archived 1'],
+                [2, 1, 'archived 2.1'],
+            ],
+        );
+
+        $this->orm = $this->withCommentsSchema([]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('firstComment', new HasOneLoadOptions(
+            table: 'comment_archive',
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertSame('archived 1', $a->firstComment->message);
+        $this->assertSame('archived 2.1', $b->firstComment->message);
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/ORM/Functional/Driver/Common/Relation/HasOne/HasOneLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/HasOne/HasOneLoadOptionsTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Relation\HasOne;
+
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\ORMInterface;
+use Cycle\ORM\Relation;
+use Cycle\ORM\Schema;
+use Cycle\ORM\Select;
+use Cycle\ORM\Select\JoinableLoader;
+use Cycle\ORM\Select\Options\HasOneLoadOptions;
+use Cycle\ORM\Select\Options\LoadMethod;
+use Cycle\ORM\Tests\Fixtures\Comment;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
+use Cycle\ORM\Tests\Fixtures\User;
+use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
+use Cycle\ORM\Tests\Traits\TableTrait;
+
+abstract class HasOneLoadOptionsTest extends BaseTest
+{
+    use TableTrait;
+
+    public function testLoadWithSingleQueryMethod(): void
+    {
+        $this->orm = $this->withCommentsSchema([]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('firstComment', new HasOneLoadOptions(
+            method: LoadMethod::SingleQuery,
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertSame('msg 1', $a->firstComment->message);
+        $this->assertSame('msg 2.1', $b->firstComment->message);
+    }
+
+    public function testLoadWithOuterQueryMethod(): void
+    {
+        $this->orm = $this->withCommentsSchema([]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('firstComment', new HasOneLoadOptions(
+            method: LoadMethod::OuterQuery,
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertSame('msg 1', $a->firstComment->message);
+        $this->assertSame('msg 2.1', $b->firstComment->message);
+    }
+
+    public function testLoadWithCustomWhere(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'ASC']),
+            Relation::SCHEMA => [Relation::WHERE => ['@.level' => ['>=' => 2]]],
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->orderBy('user.id')->load('firstComment', new HasOneLoadOptions(
+            where: ['@.level' => 1],
+        ))->fetchAll();
+
+        $this->assertSame('msg 1', $a->firstComment->message);
+        $this->assertSame('msg 2.1', $b->firstComment->message);
+    }
+
+    public function testLoadWithCustomWhereAndSingleQuery(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'ASC']),
+            Relation::SCHEMA => [Relation::WHERE => ['@.level' => ['>=' => 2]]],
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->orderBy('user.id')->load('firstComment', new HasOneLoadOptions(
+            method: LoadMethod::SingleQuery,
+            where: ['@.level' => 1],
+        ))->fetchAll();
+
+        $this->assertSame('msg 1', $a->firstComment->message);
+        $this->assertSame('msg 2.1', $b->firstComment->message);
+    }
+
+    public function testLoadWithOrderBy(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Relation::SCHEMA => [
+                Relation::ORDER_BY => ['@.level' => 'DESC'],
+            ],
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('firstComment', new HasOneLoadOptions(
+            orderBy: ['@.level' => 'ASC'],
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertSame('msg 1', $a->firstComment->message);
+        $this->assertSame('msg 2.1', $b->firstComment->message);
+    }
+
+    public function testLoadWithScopeDisabled(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Schema::SCOPE => new Select\QueryScope(['@.level' => 4]),
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('firstComment', new HasOneLoadOptions(
+            scope: false,
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertSame('msg 1', $a->firstComment->message);
+        $this->assertSame('msg 2.1', $b->firstComment->message);
+    }
+
+    public function testLoadWithCustomScope(): void
+    {
+        $this->orm = $this->withCommentsSchema([]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('firstComment', new HasOneLoadOptions(
+            scope: new Select\QueryScope(['@.level' => ['>=' => 3]], ['@.level' => 'DESC']),
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertSame('msg 4', $a->firstComment->message);
+        $this->assertSame('msg 2.3', $b->firstComment->message);
+    }
+
+    public function testLoadWithSingleQueryAndScopeAndWhere(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Relation::SCHEMA => [Relation::WHERE => ['@.level' => ['>=' => 3]]],
+            Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'DESC']),
+        ]);
+
+        // Array-based call as reference
+        $expected = (new Select($this->orm, User::class))->load('firstComment', [
+            'method' => JoinableLoader::INLOAD,
+        ])->orderBy('user.id', 'DESC')->fetchAll();
+
+        // DTO-based call
+        $res = (new Select($this->orm, User::class))->load('firstComment', new HasOneLoadOptions(
+            method: LoadMethod::SingleQuery,
+        ))->orderBy('user.id', 'DESC')->fetchAll();
+
+        $this->assertCount(2, $res);
+        $this->assertSame($expected[0]->email, $res[0]->email);
+        $this->assertSame($expected[1]->email, $res[1]->email);
+        $this->assertSame($expected[0]->firstComment->message, $res[0]->firstComment->message);
+        $this->assertSame($expected[1]->firstComment->message, $res[1]->firstComment->message);
+    }
+
+    public function testLoadWithDefaultOptions(): void
+    {
+        $this->orm = $this->withCommentsSchema([]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('firstComment', new HasOneLoadOptions())
+            ->orderBy('user.id')->fetchAll();
+
+        $this->assertSame('msg 1', $a->firstComment->message);
+        $this->assertSame('msg 2.1', $b->firstComment->message);
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->makeTable('user', [
+            'id' => 'primary',
+            'email' => 'string',
+            'balance' => 'float',
+        ]);
+
+        $this->getDatabase()->table('user')->insertMultiple(
+            ['email', 'balance'],
+            [
+                ['hello@world.com', 100],
+                ['another@world.com', 200],
+            ],
+        );
+
+        $this->makeTable('comment', [
+            'id' => 'primary',
+            'user_id' => 'integer',
+            'level' => 'integer',
+            'message' => 'string',
+        ]);
+
+        $this->makeFK('comment', 'user_id', 'user', 'id');
+
+        $this->getDatabase()->table('comment')->insertMultiple(
+            ['user_id', 'level', 'message'],
+            [
+                [1, 1, 'msg 1'],
+                [1, 2, 'msg 2'],
+                [1, 3, 'msg 3'],
+                [1, 4, 'msg 4'],
+                [2, 1, 'msg 2.1'],
+                [2, 2, 'msg 2.2'],
+                [2, 3, 'msg 2.3'],
+            ],
+        );
+    }
+
+    protected function withCommentsSchema(array $relationSchema): ORMInterface
+    {
+        $eSchema = [];
+        if (isset($relationSchema[Schema::SCOPE])) {
+            $eSchema[Schema::SCOPE] = $relationSchema[Schema::SCOPE];
+        }
+
+        $rSchema = $relationSchema[Relation::SCHEMA] ?? [];
+
+        return $this->orm->withSchema(new Schema([
+            User::class => [
+                Schema::ROLE => 'user',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'user',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'email', 'balance'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [
+                    'firstComment' => [
+                        Relation::TYPE => Relation::HAS_ONE,
+                        Relation::TARGET => Comment::class,
+                        Relation::SCHEMA => [
+                            Relation::CASCADE => true,
+                            Relation::INNER_KEY => 'id',
+                            Relation::OUTER_KEY => 'user_id',
+                        ] + $rSchema,
+                    ],
+                ],
+                Schema::SCOPE => SortByIDScope::class,
+            ],
+            Comment::class => [
+                Schema::ROLE => 'comment',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'comment',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'user_id', 'level', 'message'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [],
+            ] + $eSchema,
+        ]));
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Relation/ManyToMany/ManyToManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/ManyToMany/ManyToManyLoadOptionsTest.php
@@ -201,6 +201,47 @@ abstract class ManyToManyLoadOptionsTest extends BaseTest
         $this->assertCount(3, $b->tags);
     }
 
+    public function testLoadFromArchiveTable(): void
+    {
+        $this->makeTable('tag_archive', [
+            'id' => 'primary',
+            'level' => 'integer',
+            'name' => 'string',
+        ]);
+
+        $this->getDatabase()->table('tag_archive')->insertMultiple(
+            ['id', 'name', 'level'],
+            [
+                [1, 'archived a', 1],
+                [2, 'archived b', 2],
+                [3, 'archived c', 3],
+                [4, 'archived d', 4],
+                [5, 'archived e', 5],
+                [6, 'archived f', 6],
+            ],
+        );
+
+        $this->orm = $this->withTagSchema([
+            Relation::SCHEMA => [Relation::ORDER_BY => ['@.level' => 'ASC']],
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('tags', new ManyToManyLoadOptions(
+            table: 'tag_archive',
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertCount(4, $a->tags);
+        $this->assertCount(3, $b->tags);
+
+        $this->assertSame('archived a', $a->tags[0]->name);
+        $this->assertSame('archived b', $a->tags[1]->name);
+        $this->assertSame('archived d', $a->tags[2]->name);
+        $this->assertSame('archived e', $a->tags[3]->name);
+
+        $this->assertSame('archived c', $b->tags[0]->name);
+        $this->assertSame('archived d', $b->tags[1]->name);
+        $this->assertSame('archived f', $b->tags[2]->name);
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/ORM/Functional/Driver/Common/Relation/ManyToMany/ManyToManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/ManyToMany/ManyToManyLoadOptionsTest.php
@@ -8,6 +8,7 @@ use Cycle\ORM\Mapper\Mapper;
 use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
 use Cycle\ORM\Select;
+use Cycle\ORM\Select\JoinableLoader;
 use Cycle\ORM\Select\Options\LoadMethod;
 use Cycle\ORM\Select\Options\ManyToManyLoadOptions;
 use Cycle\ORM\Tests\Fixtures\Tag;
@@ -26,21 +27,26 @@ abstract class ManyToManyLoadOptionsTest extends BaseTest
             Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'ASC']),
         ]);
 
-        [$a, $b] = (new Select($this->orm, User::class))->load('tags', new ManyToManyLoadOptions(
+        // Array-based call as reference
+        $expected = (new Select($this->orm, User::class))->load('tags', [
+            'method' => JoinableLoader::INLOAD,
+        ])->orderBy('user.id')->fetchAll();
+
+        // DTO-based call
+        $res = (new Select($this->orm, User::class))->load('tags', new ManyToManyLoadOptions(
             method: LoadMethod::SingleQuery,
         ))->orderBy('user.id')->fetchAll();
 
-        $this->assertCount(4, $a->tags);
-        $this->assertCount(3, $b->tags);
+        $this->assertCount(\count($expected), $res);
+        $this->assertCount(\count($expected[0]->tags), $res[0]->tags);
+        $this->assertCount(\count($expected[1]->tags), $res[1]->tags);
 
-        $this->assertSame('tag a', $a->tags[0]->name);
-        $this->assertSame('tag b', $a->tags[1]->name);
-        $this->assertSame('tag d', $a->tags[2]->name);
-        $this->assertSame('tag e', $a->tags[3]->name);
-
-        $this->assertSame('tag c', $b->tags[0]->name);
-        $this->assertSame('tag d', $b->tags[1]->name);
-        $this->assertSame('tag f', $b->tags[2]->name);
+        foreach ($expected[0]->tags as $i => $tag) {
+            $this->assertSame($tag->name, $res[0]->tags[$i]->name);
+        }
+        foreach ($expected[1]->tags as $i => $tag) {
+            $this->assertSame($tag->name, $res[1]->tags[$i]->name);
+        }
     }
 
     public function testLoadWithOuterQueryMethod(): void
@@ -74,7 +80,7 @@ abstract class ManyToManyLoadOptionsTest extends BaseTest
 
         [$a, $b] = (new Select($this->orm, User::class))->load('tags', new ManyToManyLoadOptions(
             orderBy: ['@.level' => 'ASC'],
-        ))->fetchAll();
+        ))->orderBy('user.id')->fetchAll();
 
         $this->assertCount(4, $a->tags);
         $this->assertCount(3, $b->tags);
@@ -162,19 +168,26 @@ abstract class ManyToManyLoadOptionsTest extends BaseTest
             Relation::SCHEMA => [Relation::WHERE => ['@.level' => ['>=' => 3]]],
         ]);
 
-        [$a, $b] = (new Select($this->orm, User::class))->load('tags', new ManyToManyLoadOptions(
+        // Array-based call as reference
+        $expected = (new Select($this->orm, User::class))->load('tags', [
+            'method' => JoinableLoader::INLOAD,
+        ])->orderBy('user.id')->fetchAll();
+
+        // DTO-based call
+        $res = (new Select($this->orm, User::class))->load('tags', new ManyToManyLoadOptions(
             method: LoadMethod::SingleQuery,
         ))->orderBy('user.id')->fetchAll();
 
-        $this->assertCount(2, $a->tags);
-        $this->assertCount(3, $b->tags);
+        $this->assertCount(\count($expected), $res);
+        $this->assertCount(\count($expected[0]->tags), $res[0]->tags);
+        $this->assertCount(\count($expected[1]->tags), $res[1]->tags);
 
-        $this->assertSame('tag d', $a->tags[0]->name);
-        $this->assertSame('tag e', $a->tags[1]->name);
-
-        $this->assertSame('tag c', $b->tags[0]->name);
-        $this->assertSame('tag d', $b->tags[1]->name);
-        $this->assertSame('tag f', $b->tags[2]->name);
+        foreach ($expected[0]->tags as $i => $tag) {
+            $this->assertSame($tag->name, $res[0]->tags[$i]->name);
+        }
+        foreach ($expected[1]->tags as $i => $tag) {
+            $this->assertSame($tag->name, $res[1]->tags[$i]->name);
+        }
     }
 
     public function testLoadWithDefaultOptions(): void

--- a/tests/ORM/Functional/Driver/Common/Relation/ManyToMany/ManyToManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/ManyToMany/ManyToManyLoadOptionsTest.php
@@ -1,0 +1,308 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Relation\ManyToMany;
+
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\Relation;
+use Cycle\ORM\Schema;
+use Cycle\ORM\Select;
+use Cycle\ORM\Select\Options\LoadMethod;
+use Cycle\ORM\Select\Options\ManyToManyLoadOptions;
+use Cycle\ORM\Tests\Fixtures\Tag;
+use Cycle\ORM\Tests\Fixtures\TagContext;
+use Cycle\ORM\Tests\Fixtures\User;
+use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
+use Cycle\ORM\Tests\Traits\TableTrait;
+
+abstract class ManyToManyLoadOptionsTest extends BaseTest
+{
+    use TableTrait;
+
+    public function testLoadWithSingleQueryMethod(): void
+    {
+        $this->orm = $this->withTagSchema([
+            Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'ASC']),
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('tags', new ManyToManyLoadOptions(
+            method: LoadMethod::SingleQuery,
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertCount(4, $a->tags);
+        $this->assertCount(3, $b->tags);
+
+        $this->assertSame('tag a', $a->tags[0]->name);
+        $this->assertSame('tag b', $a->tags[1]->name);
+        $this->assertSame('tag d', $a->tags[2]->name);
+        $this->assertSame('tag e', $a->tags[3]->name);
+
+        $this->assertSame('tag c', $b->tags[0]->name);
+        $this->assertSame('tag d', $b->tags[1]->name);
+        $this->assertSame('tag f', $b->tags[2]->name);
+    }
+
+    public function testLoadWithOuterQueryMethod(): void
+    {
+        $this->orm = $this->withTagSchema([
+            Relation::SCHEMA => [Relation::ORDER_BY => ['@.level' => 'ASC']],
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('tags', new ManyToManyLoadOptions(
+            method: LoadMethod::OuterQuery,
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertCount(4, $a->tags);
+        $this->assertCount(3, $b->tags);
+
+        $this->assertSame('tag a', $a->tags[0]->name);
+        $this->assertSame('tag b', $a->tags[1]->name);
+        $this->assertSame('tag d', $a->tags[2]->name);
+        $this->assertSame('tag e', $a->tags[3]->name);
+
+        $this->assertSame('tag c', $b->tags[0]->name);
+        $this->assertSame('tag d', $b->tags[1]->name);
+        $this->assertSame('tag f', $b->tags[2]->name);
+    }
+
+    public function testLoadWithOrderBy(): void
+    {
+        $this->orm = $this->withTagSchema([
+            Relation::SCHEMA => [Relation::ORDER_BY => ['@.level' => 'DESC']],
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('tags', new ManyToManyLoadOptions(
+            orderBy: ['@.level' => 'ASC'],
+        ))->fetchAll();
+
+        $this->assertCount(4, $a->tags);
+        $this->assertCount(3, $b->tags);
+
+        $this->assertSame('tag a', $a->tags[0]->name);
+        $this->assertSame('tag b', $a->tags[1]->name);
+        $this->assertSame('tag d', $a->tags[2]->name);
+        $this->assertSame('tag e', $a->tags[3]->name);
+
+        $this->assertSame('tag c', $b->tags[0]->name);
+        $this->assertSame('tag d', $b->tags[1]->name);
+        $this->assertSame('tag f', $b->tags[2]->name);
+    }
+
+    public function testLoadWithCustomWhere(): void
+    {
+        $this->orm = $this->withTagSchema([
+            Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'DESC']),
+            Relation::SCHEMA => [Relation::WHERE => ['@.level' => ['>=' => 3]]],
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('tags', new ManyToManyLoadOptions(
+            where: ['@.level' => 1],
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertCount(1, $a->tags);
+        $this->assertCount(0, $b->tags);
+
+        $this->assertSame('tag a', $a->tags[0]->name);
+    }
+
+    public function testLoadWithCustomWhereAndSingleQuery(): void
+    {
+        $this->orm = $this->withTagSchema([
+            Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'DESC']),
+            Relation::SCHEMA => [Relation::WHERE => ['@.level' => ['>=' => 3]]],
+        ]);
+
+        [$a] = (new Select($this->orm, User::class))->load('tags', new ManyToManyLoadOptions(
+            method: LoadMethod::SingleQuery,
+            where: ['@.level' => 1],
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertCount(1, $a->tags);
+        $this->assertSame('tag a', $a->tags[0]->name);
+    }
+
+    public function testLoadWithScopeDisabled(): void
+    {
+        $this->orm = $this->withTagSchema([
+            Schema::SCOPE => new Select\QueryScope(['@.level' => ['>=' => 5]]),
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('tags', new ManyToManyLoadOptions(
+            scope: false,
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertCount(4, $a->tags);
+        $this->assertCount(3, $b->tags);
+    }
+
+    public function testLoadWithCustomScope(): void
+    {
+        $this->orm = $this->withTagSchema([]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('tags', new ManyToManyLoadOptions(
+            scope: new Select\QueryScope(['@.level' => ['>=' => 3]], ['@.level' => 'ASC']),
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertCount(2, $a->tags);
+        $this->assertCount(3, $b->tags);
+
+        $this->assertSame('tag d', $a->tags[0]->name);
+        $this->assertSame('tag e', $a->tags[1]->name);
+
+        $this->assertSame('tag c', $b->tags[0]->name);
+        $this->assertSame('tag d', $b->tags[1]->name);
+        $this->assertSame('tag f', $b->tags[2]->name);
+    }
+
+    public function testLoadWithSingleQueryAndScopeAndWhere(): void
+    {
+        $this->orm = $this->withTagSchema([
+            Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'ASC']),
+            Relation::SCHEMA => [Relation::WHERE => ['@.level' => ['>=' => 3]]],
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('tags', new ManyToManyLoadOptions(
+            method: LoadMethod::SingleQuery,
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertCount(2, $a->tags);
+        $this->assertCount(3, $b->tags);
+
+        $this->assertSame('tag d', $a->tags[0]->name);
+        $this->assertSame('tag e', $a->tags[1]->name);
+
+        $this->assertSame('tag c', $b->tags[0]->name);
+        $this->assertSame('tag d', $b->tags[1]->name);
+        $this->assertSame('tag f', $b->tags[2]->name);
+    }
+
+    public function testLoadWithDefaultOptions(): void
+    {
+        $this->orm = $this->withTagSchema([]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('tags', new ManyToManyLoadOptions())
+            ->orderBy('user.id')->fetchAll();
+
+        $this->assertCount(4, $a->tags);
+        $this->assertCount(3, $b->tags);
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->makeTable('user', [
+            'id' => 'primary',
+            'email' => 'string',
+            'balance' => 'float',
+        ]);
+
+        $this->makeTable('tag', [
+            'id' => 'primary',
+            'level' => 'integer',
+            'name' => 'string',
+        ]);
+
+        $this->makeTable('tag_user_map', [
+            'id' => 'primary',
+            'user_id' => 'integer',
+            'tag_id' => 'integer',
+            'as' => 'string,nullable',
+        ]);
+
+        $this->makeFK('tag_user_map', 'user_id', 'user', 'id');
+        $this->makeFK('tag_user_map', 'tag_id', 'tag', 'id');
+
+        $this->getDatabase()->table('user')->insertMultiple(
+            ['email', 'balance'],
+            [
+                ['hello@world.com', 100],
+                ['another@world.com', 200],
+            ],
+        );
+
+        $this->getDatabase()->table('tag')->insertMultiple(
+            ['name', 'level'],
+            [
+                ['tag a', 1],
+                ['tag b', 2],
+                ['tag c', 3],
+                ['tag d', 4],
+                ['tag e', 5],
+                ['tag f', 6],
+            ],
+        );
+
+        $this->getDatabase()->table('tag_user_map')->insertMultiple(
+            ['user_id', 'tag_id'],
+            [
+                [1, 1],
+                [1, 2],
+                [2, 3],
+                [1, 4],
+                [1, 5],
+                [2, 4],
+                [2, 6],
+            ],
+        );
+    }
+
+    protected function withTagSchema(array $relationSchema)
+    {
+        $eSchema = [];
+        if (isset($relationSchema[Schema::SCOPE])) {
+            $eSchema[Schema::SCOPE] = $relationSchema[Schema::SCOPE];
+        }
+
+        $rSchema = $relationSchema[Relation::SCHEMA] ?? [];
+
+        return $this->withSchema(new Schema([
+            User::class => [
+                Schema::ROLE => 'user',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'user',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'email', 'balance'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [
+                    'tags' => [
+                        Relation::TYPE => Relation::MANY_TO_MANY,
+                        Relation::TARGET => Tag::class,
+                        Relation::LOAD => Relation::LOAD_PROMISE,
+                        Relation::SCHEMA => [
+                            Relation::CASCADE => true,
+                            Relation::THROUGH_ENTITY => TagContext::class,
+                            Relation::INNER_KEY => 'id',
+                            Relation::OUTER_KEY => 'id',
+                            Relation::THROUGH_INNER_KEY => 'user_id',
+                            Relation::THROUGH_OUTER_KEY => 'tag_id',
+                        ] + $rSchema,
+                    ],
+                ],
+            ],
+            Tag::class => [
+                Schema::ROLE => 'tag',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'tag',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'name', 'level'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [],
+            ] + $eSchema,
+            TagContext::class => [
+                Schema::ROLE => 'tag_context',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'tag_user_map',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'user_id', 'tag_id', 'as'],
+                Schema::TYPECAST => ['id' => 'int', 'user_id' => 'int', 'tag_id' => 'int'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [],
+            ],
+        ]));
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Relation/ManyToMany/ManyToManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/ManyToMany/ManyToManyLoadOptionsTest.php
@@ -210,14 +210,14 @@ abstract class ManyToManyLoadOptionsTest extends BaseTest
         ]);
 
         $this->getDatabase()->table('tag_archive')->insertMultiple(
-            ['id', 'name', 'level'],
+            ['name', 'level'],
             [
-                [1, 'archived a', 1],
-                [2, 'archived b', 2],
-                [3, 'archived c', 3],
-                [4, 'archived d', 4],
-                [5, 'archived e', 5],
-                [6, 'archived f', 6],
+                ['archived a', 1],
+                ['archived b', 2],
+                ['archived c', 3],
+                ['archived d', 4],
+                ['archived e', 5],
+                ['archived f', 6],
             ],
         );
 

--- a/tests/ORM/Functional/Driver/Common/Relation/Morphed/MorphedHasManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/Morphed/MorphedHasManyLoadOptionsTest.php
@@ -1,0 +1,308 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Relation\Morphed;
+
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\Relation;
+use Cycle\ORM\Schema;
+use Cycle\ORM\Select;
+use Cycle\ORM\Select\Options\LoadMethod;
+use Cycle\ORM\Select\Options\MorphedHasManyLoadOptions;
+use Cycle\ORM\Tests\Fixtures\Comment;
+use Cycle\ORM\Tests\Fixtures\Post;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
+use Cycle\ORM\Tests\Fixtures\User;
+use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
+use Cycle\ORM\Tests\Traits\TableTrait;
+
+abstract class MorphedHasManyLoadOptionsTest extends BaseTest
+{
+    use TableTrait;
+
+    public function testLoadWithSingleQueryMethod(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'ASC']),
+        ]);
+
+        $this->logger->display();
+        [$a, $b] = (new Select($this->orm, User::class))->load('comments', new MorphedHasManyLoadOptions(
+            method: LoadMethod::SingleQuery,
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertCount(4, $a->comments);
+        $this->assertCount(3, $b->comments);
+
+        $this->assertSame('msg 1', $a->comments[0]->message);
+        $this->assertSame('msg 4', $a->comments[3]->message);
+        $this->assertSame('msg 2.1', $b->comments[0]->message);
+        $this->assertSame('msg 2.3', $b->comments[2]->message);
+    }
+
+    public function testLoadWithOuterQueryMethod(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'ASC']),
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('comments', new MorphedHasManyLoadOptions(
+            method: LoadMethod::OuterQuery,
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertCount(4, $a->comments);
+        $this->assertCount(3, $b->comments);
+
+        $this->assertSame('msg 1', $a->comments[0]->message);
+        $this->assertSame('msg 2.1', $b->comments[0]->message);
+    }
+
+    public function testLoadWithCustomWhere(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'ASC']),
+            Relation::WHERE => ['@.level' => ['>=' => 2]],
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->orderBy('user.id')->load('comments', new MorphedHasManyLoadOptions(
+            where: ['@.level' => 1],
+        ))->fetchAll();
+
+        $this->assertCount(1, $a->comments);
+        $this->assertCount(1, $b->comments);
+
+        $this->assertSame('msg 1', $a->comments[0]->message);
+        $this->assertSame('msg 2.1', $b->comments[0]->message);
+    }
+
+    public function testLoadWithCustomWhereAndSingleQuery(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'ASC']),
+            Relation::WHERE => ['@.level' => ['>=' => 2]],
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->orderBy('user.id')->load('comments', new MorphedHasManyLoadOptions(
+            method: LoadMethod::SingleQuery,
+            where: ['@.level' => 1],
+        ))->fetchAll();
+
+        $this->assertCount(1, $a->comments);
+        $this->assertCount(1, $b->comments);
+
+        $this->assertSame('msg 1', $a->comments[0]->message);
+        $this->assertSame('msg 2.1', $b->comments[0]->message);
+    }
+
+    public function testLoadWithScopeDisabled(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Schema::SCOPE => new Select\QueryScope(['@.level' => 4]),
+        ]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('comments', new MorphedHasManyLoadOptions(
+            scope: false,
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertCount(4, $a->comments);
+        $this->assertCount(3, $b->comments);
+    }
+
+    public function testLoadWithCustomScope(): void
+    {
+        $this->orm = $this->withCommentsSchema([]);
+
+        $res = (new Select($this->orm, User::class))->load('comments', new MorphedHasManyLoadOptions(
+            scope: new Select\QueryScope(['@.level' => ['>=' => 3]], ['@.level' => 'DESC']),
+        ))->orderBy('user.id')->fetchAll();
+
+        [$a, $b] = $res;
+
+        $this->assertCount(2, $a->comments);
+        $this->assertCount(1, $b->comments);
+
+        $this->assertSame('msg 4', $a->comments[0]->message);
+        $this->assertSame('msg 3', $a->comments[1]->message);
+        $this->assertSame('msg 2.3', $b->comments[0]->message);
+    }
+
+    public function testLoadWithSingleQueryAndScopeAndWhere(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Relation::WHERE => ['@.level' => ['>=' => 3]],
+            Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'DESC']),
+        ]);
+
+        // Array-based call as reference
+        $expected = (new Select($this->orm, User::class))->load('comments', [
+            'method' => Select\JoinableLoader::INLOAD,
+        ])->orderBy('user.id', 'DESC')->fetchAll();
+
+        // DTO-based call
+        $res = (new Select($this->orm, User::class))->load('comments', new MorphedHasManyLoadOptions(
+            method: LoadMethod::SingleQuery,
+        ))->orderBy('user.id', 'DESC')->fetchAll();
+
+        $this->assertCount(\count($expected), $res);
+        $this->assertSame($expected[0]->email, $res[0]->email);
+        $this->assertSame($expected[1]->email, $res[1]->email);
+
+        $this->assertCount(\count($expected[1]->comments), $res[1]->comments);
+        $this->assertCount(\count($expected[0]->comments), $res[0]->comments);
+
+        foreach ($expected[1]->comments as $i => $comment) {
+            $this->assertSame($comment->message, $res[1]->comments[$i]->message);
+        }
+        foreach ($expected[0]->comments as $i => $comment) {
+            $this->assertSame($comment->message, $res[0]->comments[$i]->message);
+        }
+    }
+
+    public function testLoadWithDefaultOptions(): void
+    {
+        $this->orm = $this->withCommentsSchema([]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('comments', new MorphedHasManyLoadOptions())
+            ->orderBy('user.id')->fetchAll();
+
+        $this->assertCount(4, $a->comments);
+        $this->assertCount(3, $b->comments);
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->makeTable('user', [
+            'id' => 'primary',
+            'email' => 'string',
+            'balance' => 'float',
+        ]);
+
+        $this->getDatabase()->table('user')->insertMultiple(
+            ['email', 'balance'],
+            [
+                ['hello@world.com', 100],
+                ['another@world.com', 200],
+            ],
+        );
+
+        $this->makeTable('post', [
+            'id' => 'primary',
+            'user_id' => 'integer,nullable',
+            'title' => 'string',
+            'content' => 'string',
+        ]);
+
+        $this->getDatabase()->table('post')->insertMultiple(
+            ['title', 'user_id', 'content'],
+            [
+                ['post 1', 1, 'post 1 body'],
+                ['post 2', 1, 'post 2 body'],
+                ['post 3', 2, 'post 3 body'],
+                ['post 4', 2, 'post 4 body'],
+            ],
+        );
+
+        $this->makeTable('comment', [
+            'id' => 'primary',
+            'parent_id' => 'integer',
+            'parent_type' => 'string',
+            'level' => 'int',
+            'message' => 'string',
+        ]);
+
+        $this->getDatabase()->table('comment')->insertMultiple(
+            ['parent_id', 'parent_type', 'level', 'message'],
+            [
+                [1, 'user', 1, 'msg 1'],
+                [1, 'user', 2, 'msg 2'],
+                [1, 'user', 3, 'msg 3'],
+                [1, 'user', 4, 'msg 4'],
+                [2, 'user', 1, 'msg 2.1'],
+                [2, 'user', 2, 'msg 2.2'],
+                [2, 'user', 3, 'msg 2.3'],
+                [1, 'post', 1, 'p.msg 1'],
+                [1, 'post', 2, 'p.msg 2'],
+                [1, 'post', 3, 'p.msg 3'],
+                [1, 'post', 4, 'p.msg 4'],
+                [2, 'post', 1, 'p.msg 2.1'],
+                [2, 'post', 2, 'p.msg 2.2'],
+                [2, 'post', 3, 'p.msg 2.3'],
+            ],
+        );
+    }
+
+    protected function withCommentsSchema(array $relationSchema)
+    {
+        $eSchema = [];
+        $rSchema = [];
+
+        if (isset($relationSchema[Schema::SCOPE])) {
+            $eSchema[Schema::SCOPE] = $relationSchema[Schema::SCOPE];
+        }
+
+        if (isset($relationSchema[Relation::WHERE])) {
+            $rSchema[Relation::WHERE] = $relationSchema[Relation::WHERE];
+        }
+
+        return $this->orm->withSchema(new Schema([
+            User::class => [
+                Schema::ROLE => 'user',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'user',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'email', 'balance'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [
+                    'comments' => [
+                        Relation::TYPE => Relation::MORPHED_HAS_MANY,
+                        Relation::TARGET => Comment::class,
+                        Relation::LOAD => Relation::LOAD_PROMISE,
+                        Relation::SCHEMA => [
+                            Relation::CASCADE => true,
+                            Relation::INNER_KEY => 'id',
+                            Relation::OUTER_KEY => 'parent_id',
+                            Relation::MORPH_KEY => 'parent_type',
+                        ] + $rSchema,
+                    ],
+                ],
+                Schema::SCOPE => SortByIDScope::class,
+            ],
+            Post::class => [
+                Schema::ROLE => 'post',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'post',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'user_id', 'title', 'content'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [
+                    'comments' => [
+                        Relation::TYPE => Relation::MORPHED_HAS_MANY,
+                        Relation::TARGET => Comment::class,
+                        Relation::LOAD => Relation::LOAD_PROMISE,
+                        Relation::SCHEMA => [
+                            Relation::CASCADE => true,
+                            Relation::INNER_KEY => 'id',
+                            Relation::OUTER_KEY => 'parent_id',
+                            Relation::MORPH_KEY => 'parent_type',
+                        ] + $rSchema,
+                    ],
+                ],
+            ],
+            Comment::class => [
+                Schema::ROLE => 'comment',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'comment',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'parent_id', 'parent_type', 'message', 'level'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [],
+            ] + $eSchema,
+        ]));
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Relation/Morphed/MorphedHasManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/Morphed/MorphedHasManyLoadOptionsTest.php
@@ -27,18 +27,26 @@ abstract class MorphedHasManyLoadOptionsTest extends BaseTest
             Schema::SCOPE => new Select\QueryScope([], ['@.level' => 'ASC']),
         ]);
 
-        $this->logger->display();
-        [$a, $b] = (new Select($this->orm, User::class))->load('comments', new MorphedHasManyLoadOptions(
+        // Array-based call as reference
+        $expected = (new Select($this->orm, User::class))->load('comments', [
+            'method' => Select\JoinableLoader::INLOAD,
+        ])->orderBy('user.id')->fetchAll();
+
+        // DTO-based call
+        $res = (new Select($this->orm, User::class))->load('comments', new MorphedHasManyLoadOptions(
             method: LoadMethod::SingleQuery,
         ))->orderBy('user.id')->fetchAll();
 
-        $this->assertCount(4, $a->comments);
-        $this->assertCount(3, $b->comments);
+        $this->assertCount(\count($expected), $res);
+        $this->assertCount(\count($expected[0]->comments), $res[0]->comments);
+        $this->assertCount(\count($expected[1]->comments), $res[1]->comments);
 
-        $this->assertSame('msg 1', $a->comments[0]->message);
-        $this->assertSame('msg 4', $a->comments[3]->message);
-        $this->assertSame('msg 2.1', $b->comments[0]->message);
-        $this->assertSame('msg 2.3', $b->comments[2]->message);
+        foreach ($expected[0]->comments as $i => $comment) {
+            $this->assertSame($comment->message, $res[0]->comments[$i]->message);
+        }
+        foreach ($expected[1]->comments as $i => $comment) {
+            $this->assertSame($comment->message, $res[1]->comments[$i]->message);
+        }
     }
 
     public function testLoadWithOuterQueryMethod(): void

--- a/tests/ORM/Functional/Driver/Common/Relation/Morphed/MorphedHasManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/Morphed/MorphedHasManyLoadOptionsTest.php
@@ -178,6 +178,40 @@ abstract class MorphedHasManyLoadOptionsTest extends BaseTest
         $this->assertCount(3, $b->comments);
     }
 
+    public function testLoadFromArchiveTable(): void
+    {
+        $this->makeTable('comment_archive', [
+            'id' => 'primary',
+            'parent_id' => 'integer',
+            'parent_type' => 'string',
+            'level' => 'int',
+            'message' => 'string',
+        ]);
+
+        $this->getDatabase()->table('comment_archive')->insertMultiple(
+            ['parent_id', 'parent_type', 'level', 'message'],
+            [
+                [1, 'user', 1, 'archived 1'],
+                [1, 'user', 2, 'archived 2'],
+                [2, 'user', 1, 'archived 2.1'],
+            ],
+        );
+
+        $this->orm = $this->withCommentsSchema([]);
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('comments', new MorphedHasManyLoadOptions(
+            table: 'comment_archive',
+            orderBy: ['@.level' => 'ASC'],
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertCount(2, $a->comments);
+        $this->assertCount(1, $b->comments);
+
+        $this->assertSame('archived 1', $a->comments[0]->message);
+        $this->assertSame('archived 2', $a->comments[1]->message);
+        $this->assertSame('archived 2.1', $b->comments[0]->message);
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/ORM/Functional/Driver/Common/Relation/Morphed/MorphedHasOneLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/Morphed/MorphedHasOneLoadOptionsTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Relation\Morphed;
+
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\Relation;
+use Cycle\ORM\Schema;
+use Cycle\ORM\Select;
+use Cycle\ORM\Select\Options\LoadMethod;
+use Cycle\ORM\Select\Options\MorphedHasOneLoadOptions;
+use Cycle\ORM\Tests\Fixtures\Image;
+use Cycle\ORM\Tests\Fixtures\Post;
+use Cycle\ORM\Tests\Fixtures\SortByIDScope;
+use Cycle\ORM\Tests\Fixtures\User;
+use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
+use Cycle\ORM\Tests\Traits\TableTrait;
+
+abstract class MorphedHasOneLoadOptionsTest extends BaseTest
+{
+    use TableTrait;
+
+    public function testLoadWithSingleQueryMethod(): void
+    {
+        [$a, $b] = (new Select($this->orm, User::class))->load('image', new MorphedHasOneLoadOptions(
+            method: LoadMethod::SingleQuery,
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertSame('user-image.png', $a->image->url);
+        $this->assertSame('user-2-image.png', $b->image->url);
+    }
+
+    public function testLoadWithOuterQueryMethod(): void
+    {
+        [$a, $b] = (new Select($this->orm, User::class))->load('image', new MorphedHasOneLoadOptions(
+            method: LoadMethod::OuterQuery,
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertSame('user-image.png', $a->image->url);
+        $this->assertSame('user-2-image.png', $b->image->url);
+    }
+
+    public function testLoadWithDefaultOptions(): void
+    {
+        [$a, $b] = (new Select($this->orm, User::class))->load('image', new MorphedHasOneLoadOptions())
+            ->orderBy('user.id')->fetchAll();
+
+        $this->assertSame('user-image.png', $a->image->url);
+        $this->assertSame('user-2-image.png', $b->image->url);
+    }
+
+    public function testLoadFromArchiveTable(): void
+    {
+        $this->makeTable('image_archive', [
+            'id' => 'primary',
+            'parent_id' => 'integer',
+            'parent_type' => 'string',
+            'url' => 'string',
+        ]);
+
+        $this->getDatabase()->table('image_archive')->insertMultiple(
+            ['parent_id', 'parent_type', 'url'],
+            [
+                [1, 'user', 'archived-user-image.png'],
+                [2, 'user', 'archived-user-2-image.png'],
+            ],
+        );
+
+        [$a, $b] = (new Select($this->orm, User::class))->load('image', new MorphedHasOneLoadOptions(
+            table: 'image_archive',
+        ))->orderBy('user.id')->fetchAll();
+
+        $this->assertSame('archived-user-image.png', $a->image->url);
+        $this->assertSame('archived-user-2-image.png', $b->image->url);
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->makeTable('user', [
+            'id' => 'primary',
+            'email' => 'string',
+            'balance' => 'float',
+        ]);
+
+        $this->getDatabase()->table('user')->insertMultiple(
+            ['email', 'balance'],
+            [
+                ['hello@world.com', 100],
+                ['another@world.com', 200],
+            ],
+        );
+
+        $this->makeTable('post', [
+            'id' => 'primary',
+            'user_id' => 'integer,nullable',
+            'title' => 'string',
+            'content' => 'string',
+        ]);
+
+        $this->getDatabase()->table('post')->insertMultiple(
+            ['title', 'user_id', 'content'],
+            [
+                ['post 1', 1, 'post 1 body'],
+                ['post 2', 1, 'post 2 body'],
+            ],
+        );
+
+        $this->makeTable('image', [
+            'id' => 'primary',
+            'parent_id' => 'integer',
+            'parent_type' => 'string',
+            'url' => 'string',
+        ]);
+
+        $this->getDatabase()->table('image')->insertMultiple(
+            ['parent_id', 'parent_type', 'url'],
+            [
+                [1, 'user', 'user-image.png'],
+                [1, 'post', 'post-image.png'],
+                [2, 'user', 'user-2-image.png'],
+                [2, 'post', 'post-2-image.png'],
+            ],
+        );
+
+        $this->orm = $this->withSchema(new Schema([
+            User::class => [
+                Schema::ROLE => 'user',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'user',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'email', 'balance'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [
+                    'image' => [
+                        Relation::TYPE => Relation::MORPHED_HAS_ONE,
+                        Relation::TARGET => Image::class,
+                        Relation::SCHEMA => [
+                            Relation::CASCADE => true,
+                            Relation::INNER_KEY => 'id',
+                            Relation::OUTER_KEY => 'parent_id',
+                            Relation::MORPH_KEY => 'parent_type',
+                        ],
+                    ],
+                ],
+                Schema::SCOPE => SortByIDScope::class,
+            ],
+            Post::class => [
+                Schema::ROLE => 'post',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'post',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'user_id', 'title', 'content'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [
+                    'image' => [
+                        Relation::TYPE => Relation::MORPHED_HAS_ONE,
+                        Relation::TARGET => Image::class,
+                        Relation::SCHEMA => [
+                            Relation::CASCADE => true,
+                            Relation::INNER_KEY => 'id',
+                            Relation::OUTER_KEY => 'parent_id',
+                            Relation::MORPH_KEY => 'parent_type',
+                        ],
+                    ],
+                ],
+            ],
+            Image::class => [
+                Schema::ROLE => 'image',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'image',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => ['id', 'parent_id', 'parent_type', 'url'],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [],
+            ],
+        ]));
+    }
+}

--- a/tests/ORM/Functional/Driver/MySQL/Relation/BelongsTo/BelongsToLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Relation/BelongsTo/BelongsToLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\MySQL\Relation\BelongsTo;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\BelongsTo\BelongsToLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class BelongsToLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/ORM/Functional/Driver/MySQL/Relation/HasMany/HasManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Relation/HasMany/HasManyLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\MySQL\Relation\HasMany;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\HasMany\HasManyLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class HasManyLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/ORM/Functional/Driver/MySQL/Relation/HasOne/HasOneLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Relation/HasOne/HasOneLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\MySQL\Relation\HasOne;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\HasOne\HasOneLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class HasOneLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/ORM/Functional/Driver/MySQL/Relation/ManyToMany/ManyToManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Relation/ManyToMany/ManyToManyLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\MySQL\Relation\ManyToMany;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\ManyToMany\ManyToManyLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class ManyToManyLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/ORM/Functional/Driver/MySQL/Relation/Morphed/MorphedHasManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Relation/Morphed/MorphedHasManyLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\MySQL\Relation\Morphed;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\Morphed\MorphedHasManyLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class MorphedHasManyLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/ORM/Functional/Driver/MySQL/Relation/Morphed/MorphedHasOneLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Relation/Morphed/MorphedHasOneLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\MySQL\Relation\Morphed;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\Morphed\MorphedHasOneLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class MorphedHasOneLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/ORM/Functional/Driver/Postgres/Relation/BelongsTo/BelongsToLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Relation/BelongsTo/BelongsToLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Postgres\Relation\BelongsTo;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\BelongsTo\BelongsToLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class BelongsToLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/ORM/Functional/Driver/Postgres/Relation/HasMany/HasManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Relation/HasMany/HasManyLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Postgres\Relation\HasMany;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\HasMany\HasManyLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class HasManyLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/ORM/Functional/Driver/Postgres/Relation/HasOne/HasOneLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Relation/HasOne/HasOneLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Postgres\Relation\HasOne;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\HasOne\HasOneLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class HasOneLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/ORM/Functional/Driver/Postgres/Relation/ManyToMany/ManyToManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Relation/ManyToMany/ManyToManyLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Postgres\Relation\ManyToMany;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\ManyToMany\ManyToManyLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class ManyToManyLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/ORM/Functional/Driver/Postgres/Relation/Morphed/MorphedHasManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Relation/Morphed/MorphedHasManyLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Postgres\Relation\Morphed;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\Morphed\MorphedHasManyLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class MorphedHasManyLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/ORM/Functional/Driver/Postgres/Relation/Morphed/MorphedHasOneLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Relation/Morphed/MorphedHasOneLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Postgres\Relation\Morphed;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\Morphed\MorphedHasOneLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class MorphedHasOneLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/ORM/Functional/Driver/SQLServer/Relation/BelongsTo/BelongsToLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Relation/BelongsTo/BelongsToLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLServer\Relation\BelongsTo;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\BelongsTo\BelongsToLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class BelongsToLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/ORM/Functional/Driver/SQLServer/Relation/HasMany/HasManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Relation/HasMany/HasManyLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLServer\Relation\HasMany;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\HasMany\HasManyLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class HasManyLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/ORM/Functional/Driver/SQLServer/Relation/HasOne/HasOneLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Relation/HasOne/HasOneLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLServer\Relation\HasOne;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\HasOne\HasOneLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class HasOneLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/ORM/Functional/Driver/SQLServer/Relation/ManyToMany/ManyToManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Relation/ManyToMany/ManyToManyLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLServer\Relation\ManyToMany;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\ManyToMany\ManyToManyLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class ManyToManyLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/ORM/Functional/Driver/SQLServer/Relation/Morphed/MorphedHasManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Relation/Morphed/MorphedHasManyLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLServer\Relation\Morphed;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\Morphed\MorphedHasManyLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class MorphedHasManyLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/ORM/Functional/Driver/SQLServer/Relation/Morphed/MorphedHasOneLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Relation/Morphed/MorphedHasOneLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLServer\Relation\Morphed;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\Morphed\MorphedHasOneLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class MorphedHasOneLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/ORM/Functional/Driver/SQLite/Relation/BelongsTo/BelongsToLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Relation/BelongsTo/BelongsToLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLite\Relation\BelongsTo;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\BelongsTo\BelongsToLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class BelongsToLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+}

--- a/tests/ORM/Functional/Driver/SQLite/Relation/HasMany/HasManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Relation/HasMany/HasManyLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLite\Relation\HasMany;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\HasMany\HasManyLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class HasManyLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+}

--- a/tests/ORM/Functional/Driver/SQLite/Relation/HasOne/HasOneLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Relation/HasOne/HasOneLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLite\Relation\HasOne;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\HasOne\HasOneLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class HasOneLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+}

--- a/tests/ORM/Functional/Driver/SQLite/Relation/ManyToMany/ManyToManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Relation/ManyToMany/ManyToManyLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLite\Relation\ManyToMany;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\ManyToMany\ManyToManyLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class ManyToManyLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+}

--- a/tests/ORM/Functional/Driver/SQLite/Relation/Morphed/MorphedHasManyLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Relation/Morphed/MorphedHasManyLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLite\Relation\Morphed;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\Morphed\MorphedHasManyLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class MorphedHasManyLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+}

--- a/tests/ORM/Functional/Driver/SQLite/Relation/Morphed/MorphedHasOneLoadOptionsTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Relation/Morphed/MorphedHasOneLoadOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLite\Relation\Morphed;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\Morphed\MorphedHasOneLoadOptionsTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class MorphedHasOneLoadOptionsTest extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+}

--- a/tests/ORM/Unit/Collection/LoophpCollectionFactoryTest.php
+++ b/tests/ORM/Unit/Collection/LoophpCollectionFactoryTest.php
@@ -122,7 +122,7 @@ class LoophpCollectionFactoryTest extends BaseTest
     {
         $factory = $this->getFactory();
         $ref = new \ReflectionProperty($factory, 'decoratorExists');
-        $ref->setAccessible(true);
+        PHP_VERSION_ID < 80100 and $ref->setAccessible(true);
         $ref->setValue($factory, false);
 
         $collection = $factory->collect(new PivotedStorage($array = [

--- a/tests/ORM/Unit/Command/InsertCommandTest.php
+++ b/tests/ORM/Unit/Command/InsertCommandTest.php
@@ -80,7 +80,7 @@ class InsertCommandTest extends TestCase
     {
         $class = new \ReflectionClass($this->cmd);
         $property = $class->getProperty('pkColumn');
-        $property->setAccessible(true);
+        PHP_VERSION_ID < 80100 and $property->setAccessible(true);
         $property->setValue($this->cmd, null);
 
         $table = 'table';

--- a/tests/ORM/Unit/Select/Options/BelongsToLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/BelongsToLoadOptionsTest.php
@@ -72,10 +72,7 @@ final class BelongsToLoadOptionsTest extends TestCase
         $options = new BelongsToLoadOptions();
 
         $this->assertSame([
-            'where' => null,
             'method' => LoadMethod::OuterQuery->value,
-            'as' => null,
-            'using' => null,
             'scope' => true,
             'minify' => true,
         ], $options->toArray());

--- a/tests/ORM/Unit/Select/Options/BelongsToLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/BelongsToLoadOptionsTest.php
@@ -71,7 +71,7 @@ final class BelongsToLoadOptionsTest extends TestCase
     {
         $options = new BelongsToLoadOptions();
 
-        $this->assertSame([
+        $this->assertEquals([
             'method' => LoadMethod::OuterQuery->value,
             'scope' => true,
             'minify' => true,
@@ -92,5 +92,15 @@ final class BelongsToLoadOptionsTest extends TestCase
         $this->assertSame($where, $result['where']);
         $this->assertSame(LoadMethod::SingleQuery->value, $result['method']);
         $this->assertFalse($result['scope']);
+    }
+
+    public function testToArrayWithEmptyWhere(): void
+    {
+        $options = new BelongsToLoadOptions(where: []);
+
+        $result = $options->toArray();
+
+        $this->assertArrayHasKey('where', $result);
+        $this->assertSame([], $result['where']);
     }
 }

--- a/tests/ORM/Unit/Select/Options/BelongsToLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/BelongsToLoadOptionsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Unit\Select\Options;
+
+use Cycle\ORM\Select\Options\BelongsToLoadOptions;
+use Cycle\ORM\Select\Options\JoinableLoadOptions;
+use Cycle\ORM\Select\Options\LoadMethod;
+use Cycle\ORM\Select\Options\LoadOptions;
+use PHPUnit\Framework\TestCase;
+
+final class BelongsToLoadOptionsTest extends TestCase
+{
+    public function testDefaults(): void
+    {
+        $options = new BelongsToLoadOptions();
+
+        $this->assertSame(LoadMethod::OuterQuery, $options->method);
+        $this->assertTrue($options->scope);
+        $this->assertTrue($options->minify);
+        $this->assertNull($options->as);
+        $this->assertNull($options->using);
+        $this->assertNull($options->where);
+    }
+
+    public function testInheritance(): void
+    {
+        $options = new BelongsToLoadOptions();
+
+        $this->assertInstanceOf(JoinableLoadOptions::class, $options);
+        $this->assertInstanceOf(LoadOptions::class, $options);
+    }
+
+    public function testWithWhere(): void
+    {
+        $where = ['{@}.active' => true];
+        $options = new BelongsToLoadOptions(where: $where);
+
+        $this->assertSame($where, $options->where);
+    }
+
+    public function testDoesNotHaveOrderBy(): void
+    {
+        $options = new BelongsToLoadOptions();
+
+        $this->assertFalse(property_exists($options, 'orderBy'));
+    }
+
+    public function testAllParameters(): void
+    {
+        $where = ['{@}.status' => 'published'];
+        $options = new BelongsToLoadOptions(
+            method: LoadMethod::SingleQuery,
+            scope: false,
+            minify: false,
+            as: 'alias',
+            using: 'other',
+            where: $where,
+        );
+
+        $this->assertSame(LoadMethod::SingleQuery, $options->method);
+        $this->assertFalse($options->scope);
+        $this->assertFalse($options->minify);
+        $this->assertSame('alias', $options->as);
+        $this->assertSame('other', $options->using);
+        $this->assertSame($where, $options->where);
+    }
+
+    public function testToArrayDefaults(): void
+    {
+        $options = new BelongsToLoadOptions();
+
+        $this->assertSame([
+            'where' => null,
+            'method' => LoadMethod::OuterQuery->value,
+            'as' => null,
+            'using' => null,
+            'scope' => true,
+            'minify' => true,
+        ], $options->toArray());
+    }
+
+    public function testToArrayCustom(): void
+    {
+        $where = ['{@}.active' => true];
+        $options = new BelongsToLoadOptions(
+            method: LoadMethod::SingleQuery,
+            scope: false,
+            where: $where,
+        );
+
+        $result = $options->toArray();
+
+        $this->assertSame($where, $result['where']);
+        $this->assertSame(LoadMethod::SingleQuery->value, $result['method']);
+        $this->assertFalse($result['scope']);
+    }
+}

--- a/tests/ORM/Unit/Select/Options/BelongsToMorphedLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/BelongsToMorphedLoadOptionsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Unit\Select\Options;
+
+use Cycle\ORM\Select\Options\BelongsToMorphedLoadOptions;
+use Cycle\ORM\Select\Options\JoinableLoadOptions;
+use Cycle\ORM\Select\Options\LoadOptions;
+use Cycle\ORM\Select\ScopeInterface;
+use PHPUnit\Framework\TestCase;
+
+final class BelongsToMorphedLoadOptionsTest extends TestCase
+{
+    public function testDefaults(): void
+    {
+        $options = new BelongsToMorphedLoadOptions();
+
+        $this->assertTrue($options->scope);
+        $this->assertTrue($options->minify);
+    }
+
+    public function testExtendsLoadOptions(): void
+    {
+        $options = new BelongsToMorphedLoadOptions();
+
+        $this->assertInstanceOf(LoadOptions::class, $options);
+    }
+
+    public function testDoesNotExtendJoinableLoadOptions(): void
+    {
+        $options = new BelongsToMorphedLoadOptions();
+
+        $this->assertNotInstanceOf(JoinableLoadOptions::class, $options);
+    }
+
+    public function testDoesNotHaveMethodProperty(): void
+    {
+        $options = new BelongsToMorphedLoadOptions();
+
+        $this->assertFalse(property_exists($options, 'method'));
+    }
+
+    public function testDoesNotHaveAsProperty(): void
+    {
+        $options = new BelongsToMorphedLoadOptions();
+
+        $this->assertFalse(property_exists($options, 'as'));
+    }
+
+    public function testDoesNotHaveUsingProperty(): void
+    {
+        $options = new BelongsToMorphedLoadOptions();
+
+        $this->assertFalse(property_exists($options, 'using'));
+    }
+
+    public function testCustomScope(): void
+    {
+        $scope = $this->createMock(ScopeInterface::class);
+        $options = new BelongsToMorphedLoadOptions(scope: $scope);
+
+        $this->assertSame($scope, $options->scope);
+    }
+
+    public function testScopeDisabled(): void
+    {
+        $options = new BelongsToMorphedLoadOptions(scope: false);
+
+        $this->assertFalse($options->scope);
+    }
+
+    public function testMinifyDisabled(): void
+    {
+        $options = new BelongsToMorphedLoadOptions(minify: false);
+
+        $this->assertFalse($options->minify);
+    }
+
+    public function testToArrayDefaults(): void
+    {
+        $options = new BelongsToMorphedLoadOptions();
+
+        $this->assertSame([
+            'scope' => true,
+            'minify' => true,
+        ], $options->toArray());
+    }
+
+    public function testToArrayCustom(): void
+    {
+        $options = new BelongsToMorphedLoadOptions(scope: false, minify: false);
+
+        $this->assertSame([
+            'scope' => false,
+            'minify' => false,
+        ], $options->toArray());
+    }
+}

--- a/tests/ORM/Unit/Select/Options/HasManyLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/HasManyLoadOptionsTest.php
@@ -76,7 +76,7 @@ final class HasManyLoadOptionsTest extends TestCase
     {
         $options = new HasManyLoadOptions();
 
-        $this->assertSame([
+        $this->assertEquals([
             'method' => LoadMethod::OuterQuery->value,
             'scope' => true,
             'minify' => true,
@@ -100,5 +100,17 @@ final class HasManyLoadOptionsTest extends TestCase
         $this->assertSame($orderBy, $result['orderBy']);
         $this->assertSame(LoadMethod::SingleQuery->value, $result['method']);
         $this->assertFalse($result['scope']);
+    }
+
+    public function testToArrayWithEmptyArrays(): void
+    {
+        $options = new HasManyLoadOptions(where: [], orderBy: []);
+
+        $result = $options->toArray();
+
+        $this->assertArrayHasKey('where', $result);
+        $this->assertArrayHasKey('orderBy', $result);
+        $this->assertSame([], $result['where']);
+        $this->assertSame([], $result['orderBy']);
     }
 }

--- a/tests/ORM/Unit/Select/Options/HasManyLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/HasManyLoadOptionsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Unit\Select\Options;
+
+use Cycle\ORM\Select\Options\HasManyLoadOptions;
+use Cycle\ORM\Select\Options\JoinableLoadOptions;
+use Cycle\ORM\Select\Options\LoadMethod;
+use Cycle\ORM\Select\Options\LoadOptions;
+use PHPUnit\Framework\TestCase;
+
+final class HasManyLoadOptionsTest extends TestCase
+{
+    public function testDefaults(): void
+    {
+        $options = new HasManyLoadOptions();
+
+        $this->assertSame(LoadMethod::OuterQuery, $options->method);
+        $this->assertTrue($options->scope);
+        $this->assertTrue($options->minify);
+        $this->assertNull($options->as);
+        $this->assertNull($options->using);
+        $this->assertNull($options->where);
+        $this->assertNull($options->orderBy);
+    }
+
+    public function testInheritance(): void
+    {
+        $options = new HasManyLoadOptions();
+
+        $this->assertInstanceOf(JoinableLoadOptions::class, $options);
+        $this->assertInstanceOf(LoadOptions::class, $options);
+    }
+
+    public function testWithWhere(): void
+    {
+        $where = ['{@}.status' => 'public'];
+        $options = new HasManyLoadOptions(where: $where);
+
+        $this->assertSame($where, $options->where);
+    }
+
+    public function testWithOrderBy(): void
+    {
+        $orderBy = ['{@}.created_at' => 'DESC'];
+        $options = new HasManyLoadOptions(orderBy: $orderBy);
+
+        $this->assertSame($orderBy, $options->orderBy);
+    }
+
+    public function testAllParameters(): void
+    {
+        $where = ['{@}.active' => true];
+        $orderBy = ['{@}.position' => 'ASC'];
+        $options = new HasManyLoadOptions(
+            method: LoadMethod::SingleQuery,
+            scope: false,
+            minify: false,
+            as: 'alias',
+            using: 'other',
+            where: $where,
+            orderBy: $orderBy,
+        );
+
+        $this->assertSame(LoadMethod::SingleQuery, $options->method);
+        $this->assertFalse($options->scope);
+        $this->assertFalse($options->minify);
+        $this->assertSame('alias', $options->as);
+        $this->assertSame('other', $options->using);
+        $this->assertSame($where, $options->where);
+        $this->assertSame($orderBy, $options->orderBy);
+    }
+
+    public function testToArrayDefaults(): void
+    {
+        $options = new HasManyLoadOptions();
+
+        $this->assertSame([
+            'where' => null,
+            'orderBy' => null,
+            'method' => LoadMethod::OuterQuery->value,
+            'as' => null,
+            'using' => null,
+            'scope' => true,
+            'minify' => true,
+        ], $options->toArray());
+    }
+
+    public function testToArrayCustom(): void
+    {
+        $where = ['{@}.status' => 'public'];
+        $orderBy = ['{@}.position' => 'ASC'];
+        $options = new HasManyLoadOptions(
+            method: LoadMethod::SingleQuery,
+            scope: false,
+            where: $where,
+            orderBy: $orderBy,
+        );
+
+        $result = $options->toArray();
+
+        $this->assertSame($where, $result['where']);
+        $this->assertSame($orderBy, $result['orderBy']);
+        $this->assertSame(LoadMethod::SingleQuery->value, $result['method']);
+        $this->assertFalse($result['scope']);
+    }
+}

--- a/tests/ORM/Unit/Select/Options/HasManyLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/HasManyLoadOptionsTest.php
@@ -77,11 +77,7 @@ final class HasManyLoadOptionsTest extends TestCase
         $options = new HasManyLoadOptions();
 
         $this->assertSame([
-            'where' => null,
-            'orderBy' => null,
             'method' => LoadMethod::OuterQuery->value,
-            'as' => null,
-            'using' => null,
             'scope' => true,
             'minify' => true,
         ], $options->toArray());

--- a/tests/ORM/Unit/Select/Options/HasOneLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/HasOneLoadOptionsTest.php
@@ -84,7 +84,7 @@ final class HasOneLoadOptionsTest extends TestCase
     {
         $options = new HasOneLoadOptions();
 
-        $this->assertSame([
+        $this->assertEquals([
             'method' => LoadMethod::SingleQuery->value,
             'scope' => true,
             'minify' => true,
@@ -110,5 +110,17 @@ final class HasOneLoadOptionsTest extends TestCase
         $this->assertSame(LoadMethod::OuterQuery->value, $result['method']);
         $this->assertSame('alias', $result['as']);
         $this->assertFalse($result['scope']);
+    }
+
+    public function testToArrayWithEmptyArrays(): void
+    {
+        $options = new HasOneLoadOptions(where: [], orderBy: []);
+
+        $result = $options->toArray();
+
+        $this->assertArrayHasKey('where', $result);
+        $this->assertArrayHasKey('orderBy', $result);
+        $this->assertSame([], $result['where']);
+        $this->assertSame([], $result['orderBy']);
     }
 }

--- a/tests/ORM/Unit/Select/Options/HasOneLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/HasOneLoadOptionsTest.php
@@ -85,11 +85,7 @@ final class HasOneLoadOptionsTest extends TestCase
         $options = new HasOneLoadOptions();
 
         $this->assertSame([
-            'where' => null,
-            'orderBy' => null,
             'method' => LoadMethod::SingleQuery->value,
-            'as' => null,
-            'using' => null,
             'scope' => true,
             'minify' => true,
         ], $options->toArray());

--- a/tests/ORM/Unit/Select/Options/HasOneLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/HasOneLoadOptionsTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Unit\Select\Options;
+
+use Cycle\ORM\Select\Options\HasOneLoadOptions;
+use Cycle\ORM\Select\Options\JoinableLoadOptions;
+use Cycle\ORM\Select\Options\JoinMethod;
+use Cycle\ORM\Select\Options\LoadMethod;
+use Cycle\ORM\Select\Options\LoadOptions;
+use PHPUnit\Framework\TestCase;
+
+final class HasOneLoadOptionsTest extends TestCase
+{
+    public function testDefaults(): void
+    {
+        $options = new HasOneLoadOptions();
+
+        $this->assertSame(LoadMethod::SingleQuery, $options->method);
+        $this->assertTrue($options->scope);
+        $this->assertTrue($options->minify);
+        $this->assertNull($options->as);
+        $this->assertNull($options->using);
+        $this->assertNull($options->where);
+        $this->assertNull($options->orderBy);
+    }
+
+    public function testInheritance(): void
+    {
+        $options = new HasOneLoadOptions();
+
+        $this->assertInstanceOf(JoinableLoadOptions::class, $options);
+        $this->assertInstanceOf(LoadOptions::class, $options);
+    }
+
+    public function testWithWhere(): void
+    {
+        $where = ['{@}.status' => 'active'];
+        $options = new HasOneLoadOptions(where: $where);
+
+        $this->assertSame($where, $options->where);
+    }
+
+    public function testWithOrderBy(): void
+    {
+        $orderBy = ['{@}.created_at' => 'DESC'];
+        $options = new HasOneLoadOptions(orderBy: $orderBy);
+
+        $this->assertSame($orderBy, $options->orderBy);
+    }
+
+    public function testWithJoinMethod(): void
+    {
+        $options = new HasOneLoadOptions(method: JoinMethod::LeftJoin);
+
+        $this->assertSame(JoinMethod::LeftJoin, $options->method);
+    }
+
+    public function testAllParameters(): void
+    {
+        $where = ['{@}.active' => true];
+        $orderBy = ['{@}.name' => 'ASC'];
+        $options = new HasOneLoadOptions(
+            method: LoadMethod::OuterQuery,
+            scope: false,
+            minify: false,
+            as: 'alias',
+            using: 'other',
+            where: $where,
+            orderBy: $orderBy,
+        );
+
+        $this->assertSame(LoadMethod::OuterQuery, $options->method);
+        $this->assertFalse($options->scope);
+        $this->assertFalse($options->minify);
+        $this->assertSame('alias', $options->as);
+        $this->assertSame('other', $options->using);
+        $this->assertSame($where, $options->where);
+        $this->assertSame($orderBy, $options->orderBy);
+    }
+
+    public function testToArrayDefaults(): void
+    {
+        $options = new HasOneLoadOptions();
+
+        $this->assertSame([
+            'where' => null,
+            'orderBy' => null,
+            'method' => LoadMethod::SingleQuery->value,
+            'as' => null,
+            'using' => null,
+            'scope' => true,
+            'minify' => true,
+        ], $options->toArray());
+    }
+
+    public function testToArrayCustom(): void
+    {
+        $where = ['{@}.active' => true];
+        $orderBy = ['{@}.name' => 'ASC'];
+        $options = new HasOneLoadOptions(
+            method: LoadMethod::OuterQuery,
+            scope: false,
+            as: 'alias',
+            where: $where,
+            orderBy: $orderBy,
+        );
+
+        $result = $options->toArray();
+
+        $this->assertSame($where, $result['where']);
+        $this->assertSame($orderBy, $result['orderBy']);
+        $this->assertSame(LoadMethod::OuterQuery->value, $result['method']);
+        $this->assertSame('alias', $result['as']);
+        $this->assertFalse($result['scope']);
+    }
+}

--- a/tests/ORM/Unit/Select/Options/JoinMethodTest.php
+++ b/tests/ORM/Unit/Select/Options/JoinMethodTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Unit\Select\Options;
+
+use Cycle\ORM\Select\JoinableLoader;
+use Cycle\ORM\Select\Options\JoinMethod;
+use PHPUnit\Framework\TestCase;
+
+final class JoinMethodTest extends TestCase
+{
+    public function testInnerJoinValue(): void
+    {
+        $this->assertSame(JoinableLoader::JOIN, JoinMethod::InnerJoin->value);
+    }
+
+    public function testLeftJoinValue(): void
+    {
+        $this->assertSame(JoinableLoader::LEFT_JOIN, JoinMethod::LeftJoin->value);
+    }
+
+    public function testCaseCount(): void
+    {
+        $this->assertCount(2, JoinMethod::cases());
+    }
+
+    public function testFromValue(): void
+    {
+        $this->assertSame(JoinMethod::InnerJoin, JoinMethod::from(JoinableLoader::JOIN));
+        $this->assertSame(JoinMethod::LeftJoin, JoinMethod::from(JoinableLoader::LEFT_JOIN));
+    }
+}

--- a/tests/ORM/Unit/Select/Options/JoinableLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/JoinableLoadOptionsTest.php
@@ -102,7 +102,7 @@ final class JoinableLoadOptionsTest extends TestCase
             using: 'other',
         );
 
-        $this->assertSame([
+        $this->assertEquals([
             'method' => LoadMethod::SingleQuery->value,
             'as' => 'my_alias',
             'using' => 'other',
@@ -122,7 +122,7 @@ final class JoinableLoadOptionsTest extends TestCase
     {
         $options = new JoinableLoadOptions(method: LoadMethod::OuterQuery);
 
-        $this->assertSame([
+        $this->assertEquals([
             'method' => LoadMethod::OuterQuery->value,
             'scope' => true,
             'minify' => true,

--- a/tests/ORM/Unit/Select/Options/JoinableLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/JoinableLoadOptionsTest.php
@@ -124,8 +124,6 @@ final class JoinableLoadOptionsTest extends TestCase
 
         $this->assertSame([
             'method' => LoadMethod::OuterQuery->value,
-            'as' => null,
-            'using' => null,
             'scope' => true,
             'minify' => true,
         ], $options->toArray());

--- a/tests/ORM/Unit/Select/Options/JoinableLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/JoinableLoadOptionsTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Unit\Select\Options;
+
+use Cycle\ORM\Select\Options\JoinableLoadOptions;
+use Cycle\ORM\Select\Options\JoinMethod;
+use Cycle\ORM\Select\Options\LoadMethod;
+use Cycle\ORM\Select\Options\LoadOptions;
+use Cycle\ORM\Select\ScopeInterface;
+use PHPUnit\Framework\TestCase;
+
+final class JoinableLoadOptionsTest extends TestCase
+{
+    public function testDefaults(): void
+    {
+        $options = new JoinableLoadOptions();
+
+        $this->assertNull($options->method);
+        $this->assertTrue($options->scope);
+        $this->assertTrue($options->minify);
+        $this->assertNull($options->as);
+        $this->assertNull($options->using);
+    }
+
+    public function testExtendsLoadOptions(): void
+    {
+        $options = new JoinableLoadOptions();
+
+        $this->assertInstanceOf(LoadOptions::class, $options);
+    }
+
+    public function testWithLoadMethod(): void
+    {
+        $options = new JoinableLoadOptions(method: LoadMethod::SingleQuery);
+
+        $this->assertSame(LoadMethod::SingleQuery, $options->method);
+    }
+
+    public function testWithJoinMethod(): void
+    {
+        $options = new JoinableLoadOptions(method: JoinMethod::InnerJoin);
+
+        $this->assertSame(JoinMethod::InnerJoin, $options->method);
+    }
+
+    public function testWithLeftJoinMethod(): void
+    {
+        $options = new JoinableLoadOptions(method: JoinMethod::LeftJoin);
+
+        $this->assertSame(JoinMethod::LeftJoin, $options->method);
+    }
+
+    public function testCustomAlias(): void
+    {
+        $options = new JoinableLoadOptions(as: 'my_alias');
+
+        $this->assertSame('my_alias', $options->as);
+    }
+
+    public function testUsing(): void
+    {
+        $options = new JoinableLoadOptions(using: 'other_relation');
+
+        $this->assertSame('other_relation', $options->using);
+    }
+
+    public function testCustomScope(): void
+    {
+        $scope = $this->createMock(ScopeInterface::class);
+        $options = new JoinableLoadOptions(scope: $scope);
+
+        $this->assertSame($scope, $options->scope);
+    }
+
+    public function testAllParameters(): void
+    {
+        $scope = $this->createMock(ScopeInterface::class);
+        $options = new JoinableLoadOptions(
+            method: LoadMethod::OuterQuery,
+            scope: $scope,
+            minify: false,
+            as: 'alias',
+            using: 'other',
+        );
+
+        $this->assertSame(LoadMethod::OuterQuery, $options->method);
+        $this->assertSame($scope, $options->scope);
+        $this->assertFalse($options->minify);
+        $this->assertSame('alias', $options->as);
+        $this->assertSame('other', $options->using);
+    }
+
+    public function testToArrayWithLoadMethod(): void
+    {
+        $options = new JoinableLoadOptions(
+            method: LoadMethod::SingleQuery,
+            scope: false,
+            minify: false,
+            as: 'my_alias',
+            using: 'other',
+        );
+
+        $this->assertSame([
+            'method' => LoadMethod::SingleQuery->value,
+            'as' => 'my_alias',
+            'using' => 'other',
+            'scope' => false,
+            'minify' => false,
+        ], $options->toArray());
+    }
+
+    public function testToArrayWithJoinMethod(): void
+    {
+        $options = new JoinableLoadOptions(method: JoinMethod::LeftJoin);
+
+        $this->assertSame(JoinMethod::LeftJoin->value, $options->toArray()['method']);
+    }
+
+    public function testToArrayDefaults(): void
+    {
+        $options = new JoinableLoadOptions(method: LoadMethod::OuterQuery);
+
+        $this->assertSame([
+            'method' => LoadMethod::OuterQuery->value,
+            'as' => null,
+            'using' => null,
+            'scope' => true,
+            'minify' => true,
+        ], $options->toArray());
+    }
+}

--- a/tests/ORM/Unit/Select/Options/LoadMethodTest.php
+++ b/tests/ORM/Unit/Select/Options/LoadMethodTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Unit\Select\Options;
+
+use Cycle\ORM\Select;
+use Cycle\ORM\Select\JoinableLoader;
+use Cycle\ORM\Select\Options\LoadMethod;
+use PHPUnit\Framework\TestCase;
+
+final class LoadMethodTest extends TestCase
+{
+    public function testSingleQueryValue(): void
+    {
+        $this->assertSame(Select::SINGLE_QUERY, LoadMethod::SingleQuery->value);
+        $this->assertSame(JoinableLoader::INLOAD, LoadMethod::SingleQuery->value);
+    }
+
+    public function testOuterQueryValue(): void
+    {
+        $this->assertSame(Select::OUTER_QUERY, LoadMethod::OuterQuery->value);
+        $this->assertSame(JoinableLoader::POSTLOAD, LoadMethod::OuterQuery->value);
+    }
+
+    public function testCaseCount(): void
+    {
+        $this->assertCount(2, LoadMethod::cases());
+    }
+
+    public function testFromValue(): void
+    {
+        $this->assertSame(LoadMethod::SingleQuery, LoadMethod::from(JoinableLoader::INLOAD));
+        $this->assertSame(LoadMethod::OuterQuery, LoadMethod::from(JoinableLoader::POSTLOAD));
+    }
+}

--- a/tests/ORM/Unit/Select/Options/LoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/LoadOptionsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Unit\Select\Options;
+
+use Cycle\ORM\Select\Options\LoadOptions;
+use Cycle\ORM\Select\ScopeInterface;
+use PHPUnit\Framework\TestCase;
+
+final class LoadOptionsTest extends TestCase
+{
+    public function testDefaults(): void
+    {
+        $options = new LoadOptions();
+
+        $this->assertTrue($options->scope);
+        $this->assertTrue($options->minify);
+    }
+
+    public function testCustomScope(): void
+    {
+        $scope = $this->createMock(ScopeInterface::class);
+        $options = new LoadOptions(scope: $scope);
+
+        $this->assertSame($scope, $options->scope);
+    }
+
+    public function testScopeDisabled(): void
+    {
+        $options = new LoadOptions(scope: false);
+
+        $this->assertFalse($options->scope);
+    }
+
+    public function testMinifyDisabled(): void
+    {
+        $options = new LoadOptions(minify: false);
+
+        $this->assertFalse($options->minify);
+    }
+
+    public function testToArray(): void
+    {
+        $options = new LoadOptions(scope: false, minify: false);
+
+        $result = $options->toArray();
+
+        $this->assertSame(['scope' => false, 'minify' => false], $result);
+    }
+
+    public function testInheritance(): void
+    {
+        $options = new LoadOptions();
+
+        $this->assertNotInstanceOf(\Cycle\ORM\Select\Options\JoinableLoadOptions::class, $options);
+    }
+}

--- a/tests/ORM/Unit/Select/Options/ManyToManyLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/ManyToManyLoadOptionsTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Unit\Select\Options;
+
+use Cycle\ORM\Select\Options\JoinableLoadOptions;
+use Cycle\ORM\Select\Options\LoadMethod;
+use Cycle\ORM\Select\Options\LoadOptions;
+use Cycle\ORM\Select\Options\ManyToManyLoadOptions;
+use PHPUnit\Framework\TestCase;
+
+final class ManyToManyLoadOptionsTest extends TestCase
+{
+    public function testDefaults(): void
+    {
+        $options = new ManyToManyLoadOptions();
+
+        $this->assertSame(LoadMethod::OuterQuery, $options->method);
+        $this->assertTrue($options->scope);
+        $this->assertTrue($options->minify);
+        $this->assertNull($options->as);
+        $this->assertNull($options->using);
+        $this->assertNull($options->where);
+        $this->assertNull($options->orderBy);
+        $this->assertNull($options->pivot);
+    }
+
+    public function testInheritance(): void
+    {
+        $options = new ManyToManyLoadOptions();
+
+        $this->assertInstanceOf(JoinableLoadOptions::class, $options);
+        $this->assertInstanceOf(LoadOptions::class, $options);
+    }
+
+    public function testWithPivotOptions(): void
+    {
+        $pivot = ['where' => ['{@}.approved' => true]];
+        $options = new ManyToManyLoadOptions(pivot: $pivot);
+
+        $this->assertSame($pivot, $options->pivot);
+    }
+
+    public function testWithWhere(): void
+    {
+        $where = ['{@}.active' => true];
+        $options = new ManyToManyLoadOptions(where: $where);
+
+        $this->assertSame($where, $options->where);
+    }
+
+    public function testWithOrderBy(): void
+    {
+        $orderBy = ['{@}.name' => 'ASC'];
+        $options = new ManyToManyLoadOptions(orderBy: $orderBy);
+
+        $this->assertSame($orderBy, $options->orderBy);
+    }
+
+    public function testAllParameters(): void
+    {
+        $where = ['{@}.active' => true];
+        $orderBy = ['{@}.name' => 'ASC'];
+        $pivot = ['where' => ['{@}.approved' => true]];
+        $options = new ManyToManyLoadOptions(
+            method: LoadMethod::SingleQuery,
+            scope: false,
+            minify: false,
+            as: 'alias',
+            using: 'other',
+            where: $where,
+            orderBy: $orderBy,
+            pivot: $pivot,
+        );
+
+        $this->assertSame(LoadMethod::SingleQuery, $options->method);
+        $this->assertFalse($options->scope);
+        $this->assertFalse($options->minify);
+        $this->assertSame('alias', $options->as);
+        $this->assertSame('other', $options->using);
+        $this->assertSame($where, $options->where);
+        $this->assertSame($orderBy, $options->orderBy);
+        $this->assertSame($pivot, $options->pivot);
+    }
+
+    public function testToArrayDefaults(): void
+    {
+        $options = new ManyToManyLoadOptions();
+
+        $this->assertSame([
+            'where' => null,
+            'orderBy' => null,
+            'pivot' => null,
+            'method' => LoadMethod::OuterQuery->value,
+            'as' => null,
+            'using' => null,
+            'scope' => true,
+            'minify' => true,
+        ], $options->toArray());
+    }
+
+    public function testToArrayCustom(): void
+    {
+        $where = ['{@}.active' => true];
+        $orderBy = ['{@}.name' => 'ASC'];
+        $pivot = ['where' => ['{@}.approved' => true]];
+        $options = new ManyToManyLoadOptions(
+            method: LoadMethod::SingleQuery,
+            scope: false,
+            where: $where,
+            orderBy: $orderBy,
+            pivot: $pivot,
+        );
+
+        $result = $options->toArray();
+
+        $this->assertSame($where, $result['where']);
+        $this->assertSame($orderBy, $result['orderBy']);
+        $this->assertSame($pivot, $result['pivot']);
+        $this->assertSame(LoadMethod::SingleQuery->value, $result['method']);
+        $this->assertFalse($result['scope']);
+    }
+}

--- a/tests/ORM/Unit/Select/Options/ManyToManyLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/ManyToManyLoadOptionsTest.php
@@ -88,7 +88,7 @@ final class ManyToManyLoadOptionsTest extends TestCase
     {
         $options = new ManyToManyLoadOptions();
 
-        $this->assertSame([
+        $this->assertEquals([
             'method' => LoadMethod::OuterQuery->value,
             'scope' => true,
             'minify' => true,
@@ -115,5 +115,19 @@ final class ManyToManyLoadOptionsTest extends TestCase
         $this->assertSame($pivot, $result['pivot']);
         $this->assertSame(LoadMethod::SingleQuery->value, $result['method']);
         $this->assertFalse($result['scope']);
+    }
+
+    public function testToArrayWithEmptyArrays(): void
+    {
+        $options = new ManyToManyLoadOptions(where: [], orderBy: [], pivot: []);
+
+        $result = $options->toArray();
+
+        $this->assertArrayHasKey('where', $result);
+        $this->assertArrayHasKey('orderBy', $result);
+        $this->assertArrayHasKey('pivot', $result);
+        $this->assertSame([], $result['where']);
+        $this->assertSame([], $result['orderBy']);
+        $this->assertSame([], $result['pivot']);
     }
 }

--- a/tests/ORM/Unit/Select/Options/ManyToManyLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/ManyToManyLoadOptionsTest.php
@@ -89,12 +89,7 @@ final class ManyToManyLoadOptionsTest extends TestCase
         $options = new ManyToManyLoadOptions();
 
         $this->assertSame([
-            'where' => null,
-            'orderBy' => null,
-            'pivot' => null,
             'method' => LoadMethod::OuterQuery->value,
-            'as' => null,
-            'using' => null,
             'scope' => true,
             'minify' => true,
         ], $options->toArray());

--- a/tests/ORM/Unit/Select/Options/MorphedHasManyLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/MorphedHasManyLoadOptionsTest.php
@@ -77,11 +77,7 @@ final class MorphedHasManyLoadOptionsTest extends TestCase
         $options = new MorphedHasManyLoadOptions();
 
         $this->assertSame([
-            'where' => null,
-            'orderBy' => null,
             'method' => LoadMethod::OuterQuery->value,
-            'as' => null,
-            'using' => null,
             'scope' => true,
             'minify' => true,
         ], $options->toArray());

--- a/tests/ORM/Unit/Select/Options/MorphedHasManyLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/MorphedHasManyLoadOptionsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Unit\Select\Options;
+
+use Cycle\ORM\Select\Options\JoinableLoadOptions;
+use Cycle\ORM\Select\Options\LoadMethod;
+use Cycle\ORM\Select\Options\LoadOptions;
+use Cycle\ORM\Select\Options\MorphedHasManyLoadOptions;
+use PHPUnit\Framework\TestCase;
+
+final class MorphedHasManyLoadOptionsTest extends TestCase
+{
+    public function testDefaults(): void
+    {
+        $options = new MorphedHasManyLoadOptions();
+
+        $this->assertSame(LoadMethod::OuterQuery, $options->method);
+        $this->assertTrue($options->scope);
+        $this->assertTrue($options->minify);
+        $this->assertNull($options->as);
+        $this->assertNull($options->using);
+        $this->assertNull($options->where);
+        $this->assertNull($options->orderBy);
+    }
+
+    public function testInheritance(): void
+    {
+        $options = new MorphedHasManyLoadOptions();
+
+        $this->assertInstanceOf(JoinableLoadOptions::class, $options);
+        $this->assertInstanceOf(LoadOptions::class, $options);
+    }
+
+    public function testWithWhere(): void
+    {
+        $where = ['{@}.status' => 'public'];
+        $options = new MorphedHasManyLoadOptions(where: $where);
+
+        $this->assertSame($where, $options->where);
+    }
+
+    public function testWithOrderBy(): void
+    {
+        $orderBy = ['{@}.position' => 'ASC'];
+        $options = new MorphedHasManyLoadOptions(orderBy: $orderBy);
+
+        $this->assertSame($orderBy, $options->orderBy);
+    }
+
+    public function testAllParameters(): void
+    {
+        $where = ['{@}.active' => true];
+        $orderBy = ['{@}.sort' => 'DESC'];
+        $options = new MorphedHasManyLoadOptions(
+            method: LoadMethod::SingleQuery,
+            scope: false,
+            minify: false,
+            as: 'alias',
+            using: 'other',
+            where: $where,
+            orderBy: $orderBy,
+        );
+
+        $this->assertSame(LoadMethod::SingleQuery, $options->method);
+        $this->assertFalse($options->scope);
+        $this->assertFalse($options->minify);
+        $this->assertSame('alias', $options->as);
+        $this->assertSame('other', $options->using);
+        $this->assertSame($where, $options->where);
+        $this->assertSame($orderBy, $options->orderBy);
+    }
+
+    public function testToArrayDefaults(): void
+    {
+        $options = new MorphedHasManyLoadOptions();
+
+        $this->assertSame([
+            'where' => null,
+            'orderBy' => null,
+            'method' => LoadMethod::OuterQuery->value,
+            'as' => null,
+            'using' => null,
+            'scope' => true,
+            'minify' => true,
+        ], $options->toArray());
+    }
+
+    public function testToArrayCustom(): void
+    {
+        $where = ['{@}.status' => 'public'];
+        $orderBy = ['{@}.position' => 'ASC'];
+        $options = new MorphedHasManyLoadOptions(
+            method: LoadMethod::SingleQuery,
+            scope: false,
+            where: $where,
+            orderBy: $orderBy,
+        );
+
+        $result = $options->toArray();
+
+        $this->assertSame($where, $result['where']);
+        $this->assertSame($orderBy, $result['orderBy']);
+        $this->assertSame(LoadMethod::SingleQuery->value, $result['method']);
+        $this->assertFalse($result['scope']);
+    }
+}

--- a/tests/ORM/Unit/Select/Options/MorphedHasManyLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/MorphedHasManyLoadOptionsTest.php
@@ -76,7 +76,7 @@ final class MorphedHasManyLoadOptionsTest extends TestCase
     {
         $options = new MorphedHasManyLoadOptions();
 
-        $this->assertSame([
+        $this->assertEquals([
             'method' => LoadMethod::OuterQuery->value,
             'scope' => true,
             'minify' => true,
@@ -100,5 +100,17 @@ final class MorphedHasManyLoadOptionsTest extends TestCase
         $this->assertSame($orderBy, $result['orderBy']);
         $this->assertSame(LoadMethod::SingleQuery->value, $result['method']);
         $this->assertFalse($result['scope']);
+    }
+
+    public function testToArrayWithEmptyArrays(): void
+    {
+        $options = new MorphedHasManyLoadOptions(where: [], orderBy: []);
+
+        $result = $options->toArray();
+
+        $this->assertArrayHasKey('where', $result);
+        $this->assertArrayHasKey('orderBy', $result);
+        $this->assertSame([], $result['where']);
+        $this->assertSame([], $result['orderBy']);
     }
 }

--- a/tests/ORM/Unit/Select/Options/MorphedHasOneLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/MorphedHasOneLoadOptionsTest.php
@@ -77,11 +77,7 @@ final class MorphedHasOneLoadOptionsTest extends TestCase
         $options = new MorphedHasOneLoadOptions();
 
         $this->assertSame([
-            'where' => null,
-            'orderBy' => null,
             'method' => LoadMethod::SingleQuery->value,
-            'as' => null,
-            'using' => null,
             'scope' => true,
             'minify' => true,
         ], $options->toArray());

--- a/tests/ORM/Unit/Select/Options/MorphedHasOneLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/MorphedHasOneLoadOptionsTest.php
@@ -76,7 +76,7 @@ final class MorphedHasOneLoadOptionsTest extends TestCase
     {
         $options = new MorphedHasOneLoadOptions();
 
-        $this->assertSame([
+        $this->assertEquals([
             'method' => LoadMethod::SingleQuery->value,
             'scope' => true,
             'minify' => true,
@@ -100,5 +100,17 @@ final class MorphedHasOneLoadOptionsTest extends TestCase
         $this->assertSame($orderBy, $result['orderBy']);
         $this->assertSame(LoadMethod::OuterQuery->value, $result['method']);
         $this->assertFalse($result['scope']);
+    }
+
+    public function testToArrayWithEmptyArrays(): void
+    {
+        $options = new MorphedHasOneLoadOptions(where: [], orderBy: []);
+
+        $result = $options->toArray();
+
+        $this->assertArrayHasKey('where', $result);
+        $this->assertArrayHasKey('orderBy', $result);
+        $this->assertSame([], $result['where']);
+        $this->assertSame([], $result['orderBy']);
     }
 }

--- a/tests/ORM/Unit/Select/Options/MorphedHasOneLoadOptionsTest.php
+++ b/tests/ORM/Unit/Select/Options/MorphedHasOneLoadOptionsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Unit\Select\Options;
+
+use Cycle\ORM\Select\Options\JoinableLoadOptions;
+use Cycle\ORM\Select\Options\LoadMethod;
+use Cycle\ORM\Select\Options\LoadOptions;
+use Cycle\ORM\Select\Options\MorphedHasOneLoadOptions;
+use PHPUnit\Framework\TestCase;
+
+final class MorphedHasOneLoadOptionsTest extends TestCase
+{
+    public function testDefaults(): void
+    {
+        $options = new MorphedHasOneLoadOptions();
+
+        $this->assertSame(LoadMethod::SingleQuery, $options->method);
+        $this->assertTrue($options->scope);
+        $this->assertTrue($options->minify);
+        $this->assertNull($options->as);
+        $this->assertNull($options->using);
+        $this->assertNull($options->where);
+        $this->assertNull($options->orderBy);
+    }
+
+    public function testInheritance(): void
+    {
+        $options = new MorphedHasOneLoadOptions();
+
+        $this->assertInstanceOf(JoinableLoadOptions::class, $options);
+        $this->assertInstanceOf(LoadOptions::class, $options);
+    }
+
+    public function testWithWhere(): void
+    {
+        $where = ['{@}.status' => 'active'];
+        $options = new MorphedHasOneLoadOptions(where: $where);
+
+        $this->assertSame($where, $options->where);
+    }
+
+    public function testWithOrderBy(): void
+    {
+        $orderBy = ['{@}.created_at' => 'DESC'];
+        $options = new MorphedHasOneLoadOptions(orderBy: $orderBy);
+
+        $this->assertSame($orderBy, $options->orderBy);
+    }
+
+    public function testAllParameters(): void
+    {
+        $where = ['{@}.active' => true];
+        $orderBy = ['{@}.name' => 'ASC'];
+        $options = new MorphedHasOneLoadOptions(
+            method: LoadMethod::OuterQuery,
+            scope: false,
+            minify: false,
+            as: 'alias',
+            using: 'other',
+            where: $where,
+            orderBy: $orderBy,
+        );
+
+        $this->assertSame(LoadMethod::OuterQuery, $options->method);
+        $this->assertFalse($options->scope);
+        $this->assertFalse($options->minify);
+        $this->assertSame('alias', $options->as);
+        $this->assertSame('other', $options->using);
+        $this->assertSame($where, $options->where);
+        $this->assertSame($orderBy, $options->orderBy);
+    }
+
+    public function testToArrayDefaults(): void
+    {
+        $options = new MorphedHasOneLoadOptions();
+
+        $this->assertSame([
+            'where' => null,
+            'orderBy' => null,
+            'method' => LoadMethod::SingleQuery->value,
+            'as' => null,
+            'using' => null,
+            'scope' => true,
+            'minify' => true,
+        ], $options->toArray());
+    }
+
+    public function testToArrayCustom(): void
+    {
+        $where = ['{@}.active' => true];
+        $orderBy = ['{@}.name' => 'ASC'];
+        $options = new MorphedHasOneLoadOptions(
+            method: LoadMethod::OuterQuery,
+            scope: false,
+            where: $where,
+            orderBy: $orderBy,
+        );
+
+        $result = $options->toArray();
+
+        $this->assertSame($where, $result['where']);
+        $this->assertSame($orderBy, $result['orderBy']);
+        $this->assertSame(LoadMethod::OuterQuery->value, $result['method']);
+        $this->assertFalse($result['scope']);
+    }
+}


### PR DESCRIPTION
# Load Options DTO — Summary

## Motivation

`Select::load()` historically accepted raw arrays for configuration. This made the API non-discoverable:
the user had to know key names, valid value types, and which options apply to which relation type.

The DTO approach replaces untyped arrays with typed objects — one per relation type — where every option
is a named constructor parameter with a default value, a type, and a docblock.

```php
// Before
$select->load('comments', [
    'method' => Select\JoinableLoader::INLOAD,
    'where'  => ['@.status' => 'public'],
]);

// After
$select->load('comments', new HasManyLoadOptions(
    method: LoadMethod::SingleQuery,
    where: ['@.status' => 'public'],
));
```

Array syntax is still supported for backwards compatibility.

---

## DTO Hierarchy

```
LoadOptions                          # scope, minify, table
├── JoinableLoadOptions              # + method, as, using
│   ├── HasOneLoadOptions            # + where, orderBy          (default: SingleQuery)
│   ├── HasManyLoadOptions           # + where, orderBy          (default: OuterQuery)
│   ├── BelongsToLoadOptions         # + where                   (default: OuterQuery)
│   ├── ManyToManyLoadOptions        # + where, orderBy, pivot   (default: OuterQuery)
│   ├── MorphedHasOneLoadOptions     # + where, orderBy          (default: SingleQuery)
│   └── MorphedHasManyLoadOptions    # + where, orderBy          (default: OuterQuery)
└── BelongsToMorphedLoadOptions      # (no extra options)
```

All classes live in `Cycle\ORM\Select\Options`.

## Enums

| Enum         | Cases                              | Maps to           |
|--------------|------------------------------------|--------------------|
| `LoadMethod` | `SingleQuery (1)`, `OuterQuery (2)` | INLOAD / POSTLOAD |
| `JoinMethod` | `InnerJoin (3)`, `LeftJoin (4)`    | JOIN / LEFT JOIN   |

`$method` accepts `LoadMethod|JoinMethod|null`.

## Table Override (`$table`)

Every DTO exposes `?string $table` (`@var non-empty-string|null`).
When set, the loader reads data from the specified table instead of the one defined in schema.

Use case — loading from an archive:

```php
$select->load('comments', new HasManyLoadOptions(
    table: 'comment_archive',
    orderBy: ['@.created_at' => 'DESC'],
));
```

The option is available for all relation types except `BelongsToMorphed`
(target is resolved dynamically by discriminator).

## `toArray()` Mapping

Each DTO implements `toArray(): array` that converts to the legacy options format understood by loaders.
Null-valued optional fields are omitted so they don't override schema-defined defaults
(loaders merge via `$options + $this->options`).

## Integration Points

| File | Change |
|------|--------|
| `Select::load()` | Accepts `LoadOptions\|array` as second argument |
| `AbstractLoader::loadRelation()` | Converts DTO via `$options->toArray()` |
| `ManyToManyLoader::loadRelation()` | Same — signature updated to `LoadOptions\|array` |
| `ChainTrait::loadRelation()` | Abstract signature updated |

---

## Tests

### Unit Tests (`tests/ORM/Unit/Select/Options/`)

One test class per DTO + enum. Cover constructor defaults, `toArray()` output, enum values.

| Test | Covers |
|------|--------|
| LoadOptionsTest | LoadOptions |
| JoinableLoadOptionsTest | JoinableLoadOptions |
| HasOneLoadOptionsTest | HasOneLoadOptions |
| HasManyLoadOptionsTest | HasManyLoadOptions |
| BelongsToLoadOptionsTest | BelongsToLoadOptions |
| ManyToManyLoadOptionsTest | ManyToManyLoadOptions |
| MorphedHasOneLoadOptionsTest | MorphedHasOneLoadOptions |
| MorphedHasManyLoadOptionsTest | MorphedHasManyLoadOptions |
| BelongsToMorphedLoadOptionsTest | BelongsToMorphedLoadOptions |
| LoadMethodTest | LoadMethod enum |
| JoinMethodTest | JoinMethod enum |

### Functional Tests (`tests/ORM/Functional/Driver/Common/Relation/`)

Each abstract test class has driver-specific subclasses for SQLite, MySQL, Postgres, SQLServer.

| Test | Relation | Methods |
|------|----------|---------|
| HasOneLoadOptionsTest | HAS_ONE | SingleQuery, OuterQuery, Where, Where+SingleQuery, OrderBy, ScopeDisabled, CustomScope, SingleQuery+Scope+Where, Defaults, **ArchiveTable** |
| HasManyLoadOptionsTest | HAS_MANY | SingleQuery, OuterQuery, Where, Where+SingleQuery, OrderBy, ScopeDisabled, CustomScope, CustomScope+SingleQuery, SingleQuery+Scope+Where, Defaults, **ArchiveTable** |
| BelongsToLoadOptionsTest | BELONGS_TO | SingleQuery, OuterQuery, Using, Defaults, **ArchiveTable** |
| ManyToManyLoadOptionsTest | MANY_TO_MANY | SingleQuery, OuterQuery, OrderBy, Where, Where+SingleQuery, ScopeDisabled, CustomScope, SingleQuery+Scope+Where, Defaults, **ArchiveTable** |
| MorphedHasManyLoadOptionsTest | MORPHED_HAS_MANY | SingleQuery, OuterQuery, Where, Where+SingleQuery, ScopeDisabled, CustomScope, SingleQuery+Scope+Where, Defaults, **ArchiveTable** |
| MorphedHasOneLoadOptionsTest | MORPHED_HAS_ONE | SingleQuery, OuterQuery, Defaults, **ArchiveTable** |
