### PR TITLE
Fix BelongsToMorphed not clearing morph type on null relation

### DIFF
--- a/src/Relation/BelongsTo.php
+++ b/src/Relation/BelongsTo.php
@@ -120,6 +120,38 @@ class BelongsTo extends AbstractRelation implements DependencyInterface
         }
     }
 
+    protected function setNullFromRelated(Tuple $tuple, bool $isPreparing): void
+    {
+        $state = $tuple->state;
+        $node = $tuple->node;
+        if (!$this->isNullable()) {
+            if ($isPreparing) {
+                // set null unchanged fields
+                $changes = $state->getChanges();
+                foreach ($this->innerKeys as $innerKey) {
+                    if (!isset($changes[$innerKey])) {
+                        $state->register($innerKey, null);
+                        // Field must be filled
+                        $state->waitField($innerKey, true);
+                    }
+                }
+                $tuple->state->setRelationStatus($this->getName(), RelationInterface::STATUS_PROCESS);
+            } elseif (!$this->checkNullValuePossibility($tuple)) {
+                throw new NullException(\sprintf('Relation `%s`.%s can not be null.', $node->getRole(), (string) $this));
+            }
+            return;
+        }
+
+        $original = $node->getRelation($this->getName());
+        if ($original !== null) {
+            // reset keys
+            foreach ($this->innerKeys as $innerKey) {
+                $state->register($innerKey, null);
+            }
+        }
+        $state->setRelationStatus($this->getName(), RelationInterface::STATUS_RESOLVED);
+    }
+
     private function shouldPull(Tuple $tuple, Tuple $rTuple): bool
     {
         $minStatus = Tuple::STATUS_DEFERRED_RESOLVED;
@@ -216,37 +248,5 @@ class BelongsTo extends AbstractRelation implements DependencyInterface
         $tuple->state->setRelation($this->getName(), new Reference($this->target, $values));
         $tuple->state->setRelationStatus($this->getName(), RelationInterface::STATUS_RESOLVED);
         return true;
-    }
-
-    private function setNullFromRelated(Tuple $tuple, bool $isPreparing): void
-    {
-        $state = $tuple->state;
-        $node = $tuple->node;
-        if (!$this->isNullable()) {
-            if ($isPreparing) {
-                // set null unchanged fields
-                $changes = $state->getChanges();
-                foreach ($this->innerKeys as $innerKey) {
-                    if (!isset($changes[$innerKey])) {
-                        $state->register($innerKey, null);
-                        // Field must be filled
-                        $state->waitField($innerKey, true);
-                    }
-                }
-                $tuple->state->setRelationStatus($this->getName(), RelationInterface::STATUS_PROCESS);
-            } elseif (!$this->checkNullValuePossibility($tuple)) {
-                throw new NullException(\sprintf('Relation `%s`.%s can not be null.', $node->getRole(), (string) $this));
-            }
-            return;
-        }
-
-        $original = $node->getRelation($this->getName());
-        if ($original !== null) {
-            // reset keys
-            foreach ($this->innerKeys as $innerKey) {
-                $state->register($innerKey, null);
-            }
-        }
-        $state->setRelationStatus($this->getName(), RelationInterface::STATUS_RESOLVED);
     }
 }

--- a/src/Relation/Morphed/BelongsToMorphed.php
+++ b/src/Relation/Morphed/BelongsToMorphed.php
@@ -67,4 +67,11 @@ class BelongsToMorphed extends BelongsTo
     {
         // no need to validate morphed relation yet
     }
+
+    protected function setNullFromRelated(Tuple $tuple, bool $isPreparing): void
+    {
+        // Set morph key to null
+        $tuple->state->register($this->morphKey, null);
+        parent::setNullFromRelated($tuple, $isPreparing);
+    }
 }

--- a/tests/ORM/Functional/Driver/Common/Relation/Morphed/BelongsToMorphedRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/Morphed/BelongsToMorphedRelationTest.php
@@ -274,6 +274,50 @@ abstract class BelongsToMorphedRelationTest extends BaseTest
         $this->assertNull($c->parent);
     }
 
+    /**
+     * When setting a morphed relation to null, both parent_id AND parent_type
+     * should be cleared in the database.
+     */
+    public function testSetNullShouldClearMorphType(): void
+    {
+        $schemaArray = $this->getNullableMorphedSchemaArray();
+        $this->orm = $this->withSchema(new Schema($schemaArray));
+
+        $c = $this->orm->getRepository(Image::class)->findByPK(1);
+
+        // Verify the image initially has a parent_type
+        $row = $this->getDatabase()->table('image')->select()->where('id', 1)->fetchAll();
+        $this->assertSame('user', $row[0]['parent_type']);
+        $this->assertNotNull($row[0]['parent_id']);
+
+        $c->parent = null;
+        $this->save($c);
+
+        // After setting parent to null, both parent_id and parent_type should be NULL
+        $row = $this->getDatabase()->table('image')->select()->where('id', 1)->fetchAll();
+        $this->assertNull($row[0]['parent_id'], 'parent_id should be NULL after setting relation to null');
+        $this->assertNull($row[0]['parent_type'], 'parent_type should be NULL after setting relation to null');
+    }
+
+    /**
+     * When creating a new entity without setting the morphed relation,
+     * parent_type should not be written to the database.
+     */
+    public function testCreateWithoutParentShouldNotSetMorphType(): void
+    {
+        $schemaArray = $this->getNullableMorphedSchemaArray();
+        $this->orm = $this->withSchema(new Schema($schemaArray));
+
+        $c = new Image();
+        $c->url = 'no-parent.png';
+
+        $this->save($c);
+
+        $row = $this->getDatabase()->table('image')->select()->where('id', 6)->fetchAll();
+        $this->assertNull($row[0]['parent_id'], 'parent_id should be NULL for entity without parent');
+        $this->assertNull($row[0]['parent_type'], 'parent_type should be NULL for entity without parent');
+    }
+
     public function testUpdateRelation(): void
     {
         $this->captureReadQueries();


### PR DESCRIPTION
## 🔍 What was changed

Fix BelongsToMorphed not clearing morph type when relation is set to null                                               

When setting a BelongsToMorphed relation to null, only the foreign key(parent_id) was being cleared while the morph discriminator (parent_type)retained its previous value. This left the database in an inconsistentstate with parent_type pointing to a role but parent_id being NULL.

The fix makes BelongsTo::setNullFromRelated() overridable (private → protected) and overrides it in BelongsToMorphed to also register the morphKey as null.

## 📝 Checklist

- How was this tested:
  - [x] Unit tests added
