### PR TITLE
Fix Belongs To Morphed behavior for custom ways

### DIFF
--- a/src/Relation/BelongsTo.php
+++ b/src/Relation/BelongsTo.php
@@ -91,6 +91,10 @@ class BelongsTo extends AbstractRelation implements DependencyInterface
         if ($related instanceof ReferenceInterface && $related->hasValue()) {
             $related = $related->getValue();
             $state->setRelation($relName, $related);
+            if ($related === null) {
+                $state->setRelationStatus($this->getName(), RelationInterface::STATUS_RESOLVED);
+                return;
+            }
         }
         if ($related === null) {
             $this->setNullFromRelated($tuple, false);

--- a/src/Relation/Morphed/BelongsToMorphed.php
+++ b/src/Relation/Morphed/BelongsToMorphed.php
@@ -68,8 +68,11 @@ class BelongsToMorphed extends BelongsTo
 
     protected function setNullFromRelated(Tuple $tuple, bool $isPreparing): void
     {
-        // Set morph key to null
-        $tuple->state->register($this->morphKey, null);
+        if ($tuple->node->getRelation($this->getName()) !== null) {
+            // Set morph key to null if the relation was changed to null
+            $tuple->state->register($this->morphKey, null);
+        }
+
         parent::setNullFromRelated($tuple, $isPreparing);
     }
 }

--- a/src/Relation/Morphed/BelongsToMorphed.php
+++ b/src/Relation/Morphed/BelongsToMorphed.php
@@ -32,10 +32,8 @@ class BelongsToMorphed extends BelongsTo
     {
         $scope = $this->getReferenceScope($node);
         $nodeData = $node->getData();
-        if ($scope === null || !isset($nodeData[$this->morphKey])) {
-            $result = new Reference($node->getRole(), []);
-            $result->setValue(null);
-            return $result;
+        if (!isset($nodeData[$this->morphKey], $scope)) {
+            return new EmptyReference('?', null);
         }
         // $scope[$this->morphKey] = $nodeData[$this->morphKey];
         $target = $nodeData[$this->morphKey];
@@ -48,7 +46,7 @@ class BelongsToMorphed extends BelongsTo
         parent::prepare($pool, $tuple, $related, $load);
         $related = $tuple->state->getRelation($this->getName());
 
-        if ($related === null) {
+        if ($related === null || $related instanceof EmptyReference) {
             return;
         }
 

--- a/src/Select.php
+++ b/src/Select.php
@@ -210,7 +210,7 @@ class Select implements \IteratorAggregate, \Countable, PaginableInterface
      * Available DTO classes (one per relation type):
      * - {@see \Cycle\ORM\Select\Options\HasOneLoadOptions}
      * - {@see \Cycle\ORM\Select\Options\HasManyLoadOptions}
-     * - {@see \Cycle\ORM\Select\Options\BelongsToLoadOptions}
+     * - {@see \Cycle\ORM\Select\Options\BelongsToLoadOptions} applicable for both Belongs To and Refers To relations
      * - {@see \Cycle\ORM\Select\Options\ManyToManyLoadOptions}
      * - {@see \Cycle\ORM\Select\Options\MorphedHasOneLoadOptions}
      * - {@see \Cycle\ORM\Select\Options\MorphedHasManyLoadOptions}

--- a/tests/ORM/Fixtures/Image.php
+++ b/tests/ORM/Fixtures/Image.php
@@ -8,6 +8,7 @@ namespace Cycle\ORM\Tests\Fixtures;
 class Image
 {
     public $id;
+    public $parentType;
     public $parent;
     public $url;
 }

--- a/tests/ORM/Functional/Driver/Common/Relation/Morphed/BelongsToMorphedRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/Morphed/BelongsToMorphedRelationTest.php
@@ -6,6 +6,7 @@ namespace Cycle\ORM\Tests\Functional\Driver\Common\Relation\Morphed;
 
 use Cycle\ORM\Heap\Heap;
 use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\Options;
 use Cycle\ORM\Reference\ReferenceInterface;
 use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
@@ -316,6 +317,26 @@ abstract class BelongsToMorphedRelationTest extends BaseTest
         $row = $this->getDatabase()->table('image')->select()->where('id', 6)->fetchAll();
         $this->assertNull($row[0]['parent_id'], 'parent_id should be NULL for entity without parent');
         $this->assertNull($row[0]['parent_type'], 'parent_type should be NULL for entity without parent');
+    }
+
+    public function testCreateWithoutRelatedButSetMorphTypeManually(): void
+    {
+        $schemaArray = $this->getNullableMorphedSchemaArray();
+        $this->orm = $this->orm->with(
+            schema: new Schema($schemaArray),
+            options: (new Options())->withIgnoreUninitializedRelations(true),
+        );
+
+        /** @var Image $c */
+        $c = $this->orm->make(Image::class);
+        $c->url = 'no-parent.png';
+        $c->parentType = 'user';
+
+        $this->save($c);
+
+        $row = $this->getDatabase()->table('image')->select()->where('id', $c->id)->fetchAll();
+        $this->assertNull($row[0]['parent_id'], 'parent_id should be NULL for entity without parent');
+        $this->assertSame('user', $row[0]['parent_type'], 'parent_type should be NULL for entity without parent');
     }
 
     public function testUpdateRelation(): void

--- a/tests/ORM/Functional/Driver/Common/Relation/Morphed/BelongsToMorphedRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/Morphed/BelongsToMorphedRelationTest.php
@@ -290,6 +290,7 @@ abstract class BelongsToMorphedRelationTest extends BaseTest
         $row = $this->getDatabase()->table('image')->select()->where('id', 1)->fetchAll();
         $this->assertSame('user', $row[0]['parent_type']);
         $this->assertNotNull($row[0]['parent_id']);
+        $this->save($c);
 
         $c->parent = null;
         $this->save($c);
@@ -319,7 +320,7 @@ abstract class BelongsToMorphedRelationTest extends BaseTest
         $this->assertNull($row[0]['parent_type'], 'parent_type should be NULL for entity without parent');
     }
 
-    public function testCreateWithoutRelatedButSetMorphTypeManually(): void
+    public function testUsingFactoryCreateWithoutRelatedButSetMorphTypeManually(): void
     {
         $schemaArray = $this->getNullableMorphedSchemaArray();
         $this->orm = $this->orm->with(
@@ -329,6 +330,25 @@ abstract class BelongsToMorphedRelationTest extends BaseTest
 
         /** @var Image $c */
         $c = $this->orm->make(Image::class);
+        $c->url = 'no-parent.png';
+        $c->parentType = 'user';
+
+        $this->save($c);
+
+        $row = $this->getDatabase()->table('image')->select()->where('id', $c->id)->fetchAll();
+        $this->assertNull($row[0]['parent_id'], 'parent_id should be NULL for entity without parent');
+        $this->assertSame('user', $row[0]['parent_type'], 'parent_type should be NULL for entity without parent');
+    }
+
+    public function testCreateWithoutRelatedButSetMorphTypeManually(): void
+    {
+        $schemaArray = $this->getNullableMorphedSchemaArray();
+        $this->orm = $this->orm->with(
+            schema: new Schema($schemaArray),
+            options: (new Options())->withIgnoreUninitializedRelations(true),
+        );
+
+        $c = new Image();
         $c->url = 'no-parent.png';
         $c->parentType = 'user';
 

--- a/tests/ORM/Functional/Driver/Common/Relation/Morphed/BelongsToMorphedRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/Morphed/BelongsToMorphedRelationTest.php
@@ -6,7 +6,6 @@ namespace Cycle\ORM\Tests\Functional\Driver\Common\Relation\Morphed;
 
 use Cycle\ORM\Heap\Heap;
 use Cycle\ORM\Mapper\Mapper;
-use Cycle\ORM\Options;
 use Cycle\ORM\Reference\ReferenceInterface;
 use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
@@ -325,7 +324,6 @@ abstract class BelongsToMorphedRelationTest extends BaseTest
         $schemaArray = $this->getNullableMorphedSchemaArray();
         $this->orm = $this->orm->with(
             schema: new Schema($schemaArray),
-            options: (new Options())->withIgnoreUninitializedRelations(true),
         );
 
         /** @var Image $c */
@@ -345,7 +343,6 @@ abstract class BelongsToMorphedRelationTest extends BaseTest
         $schemaArray = $this->getNullableMorphedSchemaArray();
         $this->orm = $this->orm->with(
             schema: new Schema($schemaArray),
-            options: (new Options())->withIgnoreUninitializedRelations(true),
         );
 
         $c = new Image();


### PR DESCRIPTION
## 🔍 What was changed

Now, for `BelongsToMorphed` relations, you can legally manually specify the `morph_type` column (without `morph_id`). This won't work if the entity is not new and the relation was set to `null` in this EM transaction (in this case, all relation fields will be prioritized to `null`).

## 🤔 Why?

Cycle ORM allowed some flexibility for the programmer. The recent fix that reset related fields broke some existing project codebases. To fix this, the old behavior was restored and supported with tests.

Even though this behavior is backed by tests, we still recommend not doing it this way for best practice reasons.

## 📝 Checklist

<!--- add/delete as needed --->

- How was this tested:
  - [x] Tested manually
  - [x] Unit tests added
