### PR TITLE
Allow `json` type to be a scalar in the default Typecast

### DIFF
--- a/src/Parser/Typecast.php
+++ b/src/Parser/Typecast.php
@@ -71,7 +71,8 @@ final class Typecast implements CastableInterface, UncastableInterface
                         $value,
                         $this->database->getDriver()->getTimezone(),
                     ),
-                    'json' => static fn(mixed $value): array => \json_decode(
+                    // Mostly an array, but can also be a scalar type.
+                    'json' => static fn(mixed $value): mixed => \json_decode(
                         $value,
                         true,
                         512,

--- a/tests/ORM/Unit/Parser/TypecastTest.php
+++ b/tests/ORM/Unit/Parser/TypecastTest.php
@@ -212,6 +212,11 @@ class TypecastTest extends TestCase
         $this->assertSame(1917, $data['foo']);
         $this->assertSame('string', $data['bar']);
         $this->assertSame(3.14, $data['baz']);
+
+        $val = $this->typecast->uncast($data);
+        self::assertSame("1917", $val['foo']);
+        self::assertSame('"string"', $val['bar']);
+        self::assertSame("3.14", $val['baz']);
     }
 
     public function testUncast(): void

--- a/tests/ORM/Unit/Parser/TypecastTest.php
+++ b/tests/ORM/Unit/Parser/TypecastTest.php
@@ -184,7 +184,7 @@ class TypecastTest extends TestCase
         );
     }
 
-    public function testCastJsonValue(): void
+    public function testCastJsonArrayValue(): void
     {
         $this->typecast->setRules(['foo' => 'json', 'baz' => 'json']);
 
@@ -197,6 +197,21 @@ class TypecastTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $data['foo']);
         $this->assertSame(\json_encode(['bar' => 'baz']), $data['bar']);
         $this->assertNull($data['baz']);
+    }
+
+    public function testCastJsonScalarValue(): void
+    {
+        $this->typecast->setRules(['foo' => 'json', 'bar' => 'json', 'baz' => 'json']);
+
+        $data = $this->typecast->cast([
+            'foo' => \json_encode(1917, \JSON_THROW_ON_ERROR),
+            'bar' => \json_encode('string', \JSON_THROW_ON_ERROR),
+            'baz' => \json_encode(3.14, \JSON_THROW_ON_ERROR),
+        ]);
+
+        $this->assertSame(1917, $data['foo']);
+        $this->assertSame('string', $data['bar']);
+        $this->assertSame(3.14, $data['baz']);
     }
 
     public function testUncast(): void


### PR DESCRIPTION


## 🔍 What was changed

It can be used to store scalar types. It can be used to store scalar types.

## 🤔 Why?

<!-- Tell your future self why have you made these changes.
Remove this block if the reason was explained in the related issue. -->

## 📝 Checklist

<!--- add/delete as needed --->

- Closes #<!-- add issue number here -->
- How was this tested:
  - [ ] Tested manually
  - [x] Unit tests added

