### PR TITLE
Fix relation override scope lost when Select is cloned

### DIFF
--- a/src/Select/JoinableLoader.php
+++ b/src/Select/JoinableLoader.php
@@ -109,15 +109,20 @@ abstract class JoinableLoader extends AbstractLoader implements JoinableInterfac
         //Calculate table alias
         $loader->options['as'] = $loader->calculateAlias($parent);
 
-        if (\array_key_exists('scope', $options)) {
-            if ($loader->options['scope'] instanceof ScopeInterface) {
-                $loader->setScope($loader->options['scope']);
-            } elseif (\is_string($loader->options['scope'])) {
-                $loader->setScope($this->factory->make($loader->options['scope']));
-            }
-        } else {
-            $loader->setScope($this->source->getScope());
-        }
+        // Derive the scope from the persisted `scope` option rather than from the presence of
+        // the `scope` key in the passed `$options`. The option survives cloning (see the
+        // `$options + $this->options` merge above and AbstractLoader::__clone()), whereas the
+        // argument does not — re-parenting during a clone calls withContext() with no options,
+        // which previously dropped any override back to the source scope.
+        $scope = $loader->options['scope'] ?? true;
+        $loader->setScope(match (true) {
+            $scope instanceof ScopeInterface => $scope,
+            \is_string($scope) => $this->factory->make($scope),
+            // false/null explicitly disable the scope for this relation
+            $scope === false, $scope === null => null,
+            // true (the default) means: use the relation source's scope
+            default => $this->source->getScope(),
+        });
 
         if (!$loader->eagerLoaded && $loader->isLoaded()) {
             $loader->eagerLoaded = true;

--- a/tests/ORM/Functional/Driver/Common/Relation/HasMany/HasManyScopeTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/HasMany/HasManyScopeTest.php
@@ -545,6 +545,84 @@ abstract class HasManyScopeTest extends BaseTest
         $this->assertSame('msg 2.3', $userB->comments[0]->message);
     }
 
+    /**
+     * Regression: an override scope passed to load() (here `scope: false`, disabling the
+     * relation's source scope) must survive a clone of the Select. fetchAll() does not clone
+     * for a POSTLOAD relation, so it already worked; cloning re-parents the loader tree via
+     * AbstractLoader::__clone() → JoinableLoader::withContext() with empty options, whose
+     * `else` branch used to blindly re-apply the source scope, dropping the override.
+     */
+    public function testDisabledRelationScopeSurvivesClone(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            // Source scope on Comment: only level >= 2 (drops 'msg 1' and 'msg 2.1').
+            Schema::SCOPE => new Select\QueryScope(['@.level' => ['>=' => 2]]),
+        ]);
+
+        $select = (new Select($this->orm, User::class))
+            ->load('comments', ['scope' => false])
+            ->orderBy('user.id');
+
+        // Clone before executing anything so neither result is served from the heap.
+        $clone = clone $select;
+
+        // Baseline (no clone): override works, all comments are loaded.
+        [$a, $b] = $select->fetchAll();
+        $this->assertCount(4, $a->comments);
+        $this->assertCount(3, $b->comments);
+
+        // Drop identity map so the cloned query re-reads comments from the database
+        // instead of returning the already-hydrated User instances above.
+        $this->orm->getHeap()->clean();
+
+        // The clone must preserve the disabled scope.
+        [$a, $b] = $clone->fetchAll();
+        $this->assertCount(4, $a->comments);
+        $this->assertCount(3, $b->comments);
+    }
+
+    /**
+     * Regression: fetchOne() internally does `(clone $this)->where(...)->limit(1)`, so the
+     * `scope: false` override must reach the cloned loader. Before the fix the source scope
+     * (level >= 2) leaked back in and 'msg 1' was filtered out.
+     */
+    public function testFetchOneKeepsDisabledRelationScope(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Schema::SCOPE => new Select\QueryScope(['@.level' => ['>=' => 2]]),
+        ]);
+
+        $user = (new Select($this->orm, User::class))
+            ->load('comments', ['scope' => false])
+            ->wherePK(1)
+            ->fetchOne();
+
+        $this->assertNotNull($user);
+        $this->assertCount(4, $user->comments);
+    }
+
+    /**
+     * Regression: a custom override scope (not just `false`) must also survive the fetchOne()
+     * clone. Here load() overrides the source scope (level >= 2) with a stricter one
+     * (level >= 3). Before the fix the clone reset it back to the source scope, yielding 3
+     * comments instead of 2.
+     */
+    public function testFetchOneKeepsCustomRelationScopeOverride(): void
+    {
+        $this->orm = $this->withCommentsSchema([
+            Schema::SCOPE => new Select\QueryScope(['@.level' => ['>=' => 2]]),
+        ]);
+
+        $user = (new Select($this->orm, User::class))
+            ->load('comments', ['scope' => new Select\QueryScope(['@.level' => ['>=' => 3]])])
+            ->wherePK(1)
+            ->fetchOne();
+
+        $this->assertNotNull($user);
+        // level 3 and 4 only.
+        $this->assertCount(2, $user->comments);
+    }
+
     public function testInvalidOrderBy(): void
     {
         $this->expectException(StatementException::class);


### PR DESCRIPTION
## 🔍 What was changed

JoinableLoader::withContext() decided the relation scope from the presence
of the `scope` key in the *passed* `$options` argument. During a clone the
loader tree is re-parented via AbstractLoader::__clone(), which calls
withContext($this) with no options, so the code always fell into the `else`
branch and re-applied the source scope — silently discarding any override
set through load(..., scope: false) or load(..., scope: new QueryScope(...)).

Because fetchOne()/findOne() clone internally ((clone $this)->limit(1)), and
addGroupByPK() clones for paginated joined queries, the override never
reached the executed query. fetchAll() on a POSTLOAD relation does not clone,
which is why the bug escaped the existing tests.

Drive the scope decision off the persisted `options['scope']` instead. That
option survives cloning via the `$options + $this->options` merge, so the
override (false / null / ScopeInterface / string) is now preserved across
clones, while an absent key or `true` still resolves to the source scope.