### PR TITLE
Add RefersToMorphed relation for cyclic morphed references

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1653,10 +1653,22 @@
       <code><![CDATA[parent::getReferenceScope($node)]]></code>
     </PossiblyNullOperand>
   </file>
-  <file src="src/Relation/RefersTo.php">
+  <file src="src/Relation/Morphed/RefersToMorphed.php">
     <ClassMustBeFinal>
-      <code><![CDATA[RefersTo]]></code>
+      <code><![CDATA[RefersToMorphed]]></code>
     </ClassMustBeFinal>
+    <MixedArgument>
+      <code><![CDATA[$related]]></code>
+      <code><![CDATA[$target]]></code>
+      <code><![CDATA[$target]]></code>
+    </MixedArgument>
+    <MixedAssignment>
+      <code><![CDATA[$related]]></code>
+      <code><![CDATA[$target]]></code>
+      <code><![CDATA[$this->morphKey]]></code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Relation/RefersTo.php">
     <MixedArgument>
       <code><![CDATA[$related]]></code>
       <code><![CDATA[$related]]></code>
@@ -2217,14 +2229,22 @@
     <MixedArgument>
       <code><![CDATA[$row]]></code>
       <code><![CDATA[$this->define(SchemaInterface::COLUMNS)]]></code>
-      <code><![CDATA[$this->factory->make($loader->options['scope'])]]></code>
       <code><![CDATA[$this->options['minify']]]></code>
       <code><![CDATA[$this->options['minify']]]></code>
       <code><![CDATA[$this->schema[$key]]]></code>
       <code><![CDATA[$this->schema[$key]]]></code>
+      <code><![CDATA[match (true) {
+            $scope instanceof ScopeInterface => $scope,
+            \is_string($scope) => $this->factory->make($scope),
+            // false/null explicitly disable the scope for this relation
+            $scope === false, $scope === null => null,
+            // true (the default) means: use the relation source's scope
+            default => $this->source->getScope(),
+        }]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code><![CDATA[$row]]></code>
+      <code><![CDATA[$scope]]></code>
     </MixedAssignment>
     <MixedReturnStatement>
       <code><![CDATA[$this->options['as']]]></code>

--- a/src/Config/RelationConfig.php
+++ b/src/Config/RelationConfig.php
@@ -57,6 +57,10 @@ final class RelationConfig extends InjectableConfig
                 self::LOADER => Select\Loader\Morphed\BelongsToMorphedLoader::class,
                 self::RELATION => Relation\Morphed\BelongsToMorphed::class,
             ],
+            Relation::REFERS_TO_MORPHED => [
+                self::LOADER => Select\Loader\Morphed\BelongsToMorphedLoader::class,
+                self::RELATION => Relation\Morphed\RefersToMorphed::class,
+            ],
         ]);
     }
 

--- a/src/Relation.php
+++ b/src/Relation.php
@@ -29,6 +29,7 @@ final class Relation
     // Morphed relations
     public const BELONGS_TO_MORPHED = 20;
     public const MORPHED_HAS_ONE = 21;
+    public const REFERS_TO_MORPHED = 22;
     public const MORPHED_HAS_MANY = 23;
 
     // Custom morph key

--- a/src/Relation/Morphed/RefersToMorphed.php
+++ b/src/Relation/Morphed/RefersToMorphed.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Relation\Morphed;
+
+use Cycle\ORM\Exception\RelationException;
+use Cycle\ORM\Heap\Node;
+use Cycle\ORM\ORMInterface;
+use Cycle\ORM\Reference\EmptyReference;
+use Cycle\ORM\Reference\Reference;
+use Cycle\ORM\Reference\ReferenceInterface;
+use Cycle\ORM\Relation;
+use Cycle\ORM\Relation\RefersTo;
+use Cycle\ORM\Transaction\Pool;
+use Cycle\ORM\Transaction\Tuple;
+
+/**
+ * Morphed variation of the {@see RefersTo} relation. Like {@see BelongsToMorphed} it stores
+ * both the outer key and the target role (morph key) on the owner, but inherits the deferred,
+ * "soft" dependency resolution of {@see RefersTo}. This allows the relation to be self linked
+ * and to participate in cyclic references (A > A, A > B > A) that {@see BelongsToMorphed} can
+ * not persist in a single transaction.
+ *
+ * @internal
+ */
+class RefersToMorphed extends RefersTo
+{
+    private string $morphKey;
+
+    public function __construct(ORMInterface $orm, string $role, string $name, string $target, array $schema)
+    {
+        parent::__construct($orm, $role, $name, $target, $schema);
+        $this->morphKey = $schema[Relation::MORPH_KEY];
+    }
+
+    public function initReference(Node $node): ReferenceInterface
+    {
+        $scope = $this->getReferenceScope($node);
+        $nodeData = $node->getData();
+        if (!isset($nodeData[$this->morphKey], $scope)) {
+            return new EmptyReference('?', null);
+        }
+        $target = $nodeData[$this->morphKey];
+
+        return $scope === [] ? new EmptyReference($target, null) : new Reference($target, $scope);
+    }
+
+    public function prepare(Pool $pool, Tuple $tuple, mixed $related, bool $load = true): void
+    {
+        // The parent RefersTo resets the node relation while handling a null value, so capture
+        // whether there was a related entity before delegating.
+        $hadRelation = $tuple->node->getRelation($this->getName()) !== null;
+        parent::prepare($pool, $tuple, $related, $load);
+        $this->syncMorphKey($pool, $tuple, $hadRelation);
+    }
+
+    public function queue(Pool $pool, Tuple $tuple): void
+    {
+        $hadRelation = $tuple->node->getRelation($this->getName()) !== null;
+        parent::queue($pool, $tuple);
+        $this->syncMorphKey($pool, $tuple, $hadRelation);
+    }
+
+    /**
+     * Assert that given entity is allowed for the relation.
+     *
+     * @throws RelationException
+     */
+    protected function assertValid(Node $related): void
+    {
+        // no need to validate morphed relation yet
+    }
+
+    /**
+     * Keep the morph key in sync with the related entity role. The role is known as soon as the
+     * related object is available, so it can be registered eagerly even while the outer key is
+     * still deferred by the parent {@see RefersTo} logic.
+     */
+    private function syncMorphKey(Pool $pool, Tuple $tuple, bool $hadRelation): void
+    {
+        $relName = $this->getName();
+        $state = $tuple->state;
+        if (!$state->hasRelation($relName)) {
+            return;
+        }
+
+        $related = $state->getRelation($relName);
+
+        if ($related === null) {
+            // Reset the morph key when the relation was changed to null
+            if ($hadRelation) {
+                $state->register($this->morphKey, null);
+            }
+            return;
+        }
+
+        if ($related instanceof EmptyReference) {
+            return;
+        }
+
+        $role = $related instanceof ReferenceInterface
+            ? $related->getRole()
+            : $pool->offsetGet($related)?->node->getRole();
+
+        $state->register($this->morphKey, $role);
+    }
+}

--- a/tests/ORM/Fixtures/MorphedCyclic/EntityA.php
+++ b/tests/ORM/Fixtures/MorphedCyclic/EntityA.php
@@ -1,0 +1,17 @@
+<?php
+
+// phpcs:ignoreFile
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Fixtures\MorphedCyclic;
+
+class EntityA implements MorphedInterface
+{
+    public $id;
+    public $name;
+    public $parentId;
+    public $parentType;
+
+    /** @var MorphedInterface|null */
+    public $parent;
+}

--- a/tests/ORM/Fixtures/MorphedCyclic/EntityB.php
+++ b/tests/ORM/Fixtures/MorphedCyclic/EntityB.php
@@ -1,0 +1,17 @@
+<?php
+
+// phpcs:ignoreFile
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Fixtures\MorphedCyclic;
+
+class EntityB implements MorphedInterface
+{
+    public $id;
+    public $name;
+    public $parentId;
+    public $parentType;
+
+    /** @var MorphedInterface|null */
+    public $parent;
+}

--- a/tests/ORM/Fixtures/MorphedCyclic/MorphedInterface.php
+++ b/tests/ORM/Fixtures/MorphedCyclic/MorphedInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+// phpcs:ignoreFile
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Fixtures\MorphedCyclic;
+
+interface MorphedInterface {}

--- a/tests/ORM/Functional/Driver/Common/Relation/Morphed/BelongsToMorphedRelationTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/Morphed/BelongsToMorphedRelationTest.php
@@ -6,6 +6,7 @@ namespace Cycle\ORM\Tests\Functional\Driver\Common\Relation\Morphed;
 
 use Cycle\ORM\Heap\Heap;
 use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\Options;
 use Cycle\ORM\Reference\ReferenceInterface;
 use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
@@ -372,6 +373,47 @@ abstract class BelongsToMorphedRelationTest extends BaseTest
             $this->assertNotNull($image->parent);
         }
         $this->assertNumReads(0);
+    }
+
+    /**
+     * With ignoreUninitializedRelations = true (BaseTest default) unsetting the relation property
+     * must leave both the outer key and the morph key untouched.
+     */
+    public function testUnsetParentKeepsMorphWhenIgnoringUninitialized(): void
+    {
+        $c = $this->orm->getRepository(Image::class)->findByPK(1);
+        $this->assertInstanceOf(User::class, $c->parent);
+        unset($c->parent);
+
+        $this->captureWriteQueries();
+        $this->save($c);
+        $this->assertNumWrites(0);
+
+        $row = $this->getDatabase()->table('image')->select()->where('id', 1)->fetchAll();
+        $this->assertSame('1', (string) $row[0]['parent_id']);
+        $this->assertSame('user', $row[0]['parent_type']);
+    }
+
+    /**
+     * With ignoreUninitializedRelations = false an unset relation is treated as null, so both the
+     * outer key and the morph key must be cleared.
+     */
+    public function testUnsetParentClearsMorphWithoutIgnoreUninitialized(): void
+    {
+        $this->orm = $this->withSchema(new Schema($this->getNullableMorphedSchemaArray()))
+            ->with(options: (new Options())->withIgnoreUninitializedRelations(false));
+
+        $c = $this->orm->getRepository(Image::class)->findByPK(1);
+        $this->assertInstanceOf(User::class, $c->parent);
+        unset($c->parent);
+
+        $this->captureWriteQueries();
+        $this->save($c);
+        $this->assertNumWrites(1);
+
+        $row = $this->getDatabase()->table('image')->select()->where('id', 1)->fetchAll();
+        $this->assertNull($row[0]['parent_id'], 'parent_id should be NULL when the unset relation is treated as null');
+        $this->assertNull($row[0]['parent_type'], 'parent_type should be NULL when the unset relation is treated as null');
     }
 
     public function setUp(): void

--- a/tests/ORM/Functional/Driver/Common/Relation/Morphed/RefersToMorphedCyclicTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/Morphed/RefersToMorphedCyclicTest.php
@@ -55,6 +55,42 @@ abstract class RefersToMorphedCyclicTest extends BaseTest
         $this->assertSame($a->id, $a->parent->parent->id);
     }
 
+    /**
+     * The relation is loaded lazily: a self-reference resolves to the already-loaded entity
+     * straight from the heap, without issuing an extra query.
+     */
+    public function testLazyLoadSelfReferenceResolvesFromHeap(): void
+    {
+        $a = $this->orm->getRepository(EntityA::class)->findByPK(1);
+        // Not resolved yet — the relation is a promise reference.
+        $this->assertInstanceOf(ReferenceInterface::class, $this->extractEntity($a)['parent']);
+
+        $this->captureReadQueries();
+        $this->assertSame($a, $a->parent);
+        $this->assertNumReads(0);
+    }
+
+    /**
+     * Lazy loading across a morphed cycle: resolving the parent that is not in the heap costs
+     * exactly one query, while the back-reference is taken from the heap for free.
+     */
+    public function testLazyLoadCycleTwoEntities(): void
+    {
+        $a = $this->orm->getRepository(EntityA::class)->findByPK(2);
+        $this->assertInstanceOf(ReferenceInterface::class, $this->extractEntity($a)['parent']);
+
+        // entity_b #1 is not in the heap yet -> exactly one lazy query.
+        $this->captureReadQueries();
+        $b = $a->parent;
+        $this->assertInstanceOf(EntityB::class, $b);
+        $this->assertNumReads(1);
+
+        // The back-reference entity_a #2 is already in the heap -> no extra query.
+        $this->captureReadQueries();
+        $this->assertSame($a, $b->parent);
+        $this->assertNumReads(0);
+    }
+
     public function testSetSelfReferenceToNull(): void
     {
         $a = $this->orm->getRepository(EntityA::class)->findByPK(1);

--- a/tests/ORM/Functional/Driver/Common/Relation/Morphed/RefersToMorphedCyclicTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/Morphed/RefersToMorphedCyclicTest.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Common\Relation\Morphed;
+
+use Cycle\ORM\Heap\Heap;
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\Options;
+use Cycle\ORM\Reference\ReferenceInterface;
+use Cycle\ORM\Relation;
+use Cycle\ORM\Schema;
+use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
+use Cycle\ORM\Tests\Fixtures\MorphedCyclic\EntityA;
+use Cycle\ORM\Tests\Fixtures\MorphedCyclic\EntityB;
+use Cycle\ORM\Tests\Fixtures\MorphedCyclic\MorphedInterface;
+use Cycle\ORM\Tests\Traits\TableTrait;
+
+/**
+ * Cyclic dependencies via {@see Relation::REFERS_TO_MORPHED}:
+ *  - A > A: an entity points to itself through a morphed relation;
+ *  - A > B > A: two entities point at each other through morphed relations.
+ *
+ * Unlike {@see Relation::BELONGS_TO_MORPHED} (a hard "parent before child" dependency that
+ * deadlocks the pool on a cycle), the morphed refers-to relation resolves the outer key in a
+ * deferred way and therefore is able to persist a closed cycle within a single transaction.
+ * The related entity is resolved lazily through a promise reference.
+ */
+abstract class RefersToMorphedCyclicTest extends BaseTest
+{
+    use TableTrait;
+
+    public function testFetchSelfReference(): void
+    {
+        // entity_a #1 references itself
+        $a = $this->orm->getRepository(EntityA::class)->findByPK(1);
+        $data = $this->extractEntity($a);
+
+        $this->assertInstanceOf(ReferenceInterface::class, $data['parent']);
+
+        $this->assertInstanceOf(EntityA::class, $a->parent);
+        $this->assertSame('a-self', $a->parent->name);
+        $this->assertSame($a->id, $a->parent->id);
+    }
+
+    public function testFetchCycleTwoEntities(): void
+    {
+        // entity_a #2 -> entity_b #1 -> entity_a #2
+        $a = $this->orm->getRepository(EntityA::class)->findByPK(2);
+
+        $this->assertInstanceOf(EntityB::class, $a->parent);
+        $this->assertSame('b-1', $a->parent->name);
+
+        $this->assertInstanceOf(EntityA::class, $a->parent->parent);
+        $this->assertSame($a->id, $a->parent->parent->id);
+    }
+
+    public function testSetSelfReferenceToNull(): void
+    {
+        $a = $this->orm->getRepository(EntityA::class)->findByPK(1);
+        $this->assertInstanceOf(EntityA::class, $a->parent);
+
+        $a->parent = null;
+        $this->save($a);
+
+        $row = $this->getDatabase()->table('entity_a')->select()->where('id', 1)->fetchAll();
+        $this->assertNull($row[0]['parent_id'], 'parent_id should be NULL after detaching self-reference');
+        $this->assertNull($row[0]['parent_type'], 'parent_type should be NULL after detaching self-reference');
+    }
+
+    public function testCreateSelfReference(): void
+    {
+        $a = new EntityA();
+        $a->name = 'new-self';
+        $a->parent = $a;
+
+        $this->captureWriteQueries();
+        $this->save($a);
+        // INSERT the row, then a deferred UPDATE with its own id + morph type
+        $this->assertNumWrites(2);
+
+        // consecutive save does nothing
+        $this->captureWriteQueries();
+        $this->save($a);
+        $this->assertNumWrites(0);
+
+        $this->assertSame($a->id, $a->parentId);
+        $this->assertSame('entity_a', $a->parentType);
+
+        $row = $this->getDatabase()->table('entity_a')->select()->where('id', $a->id)->fetchAll();
+        $this->assertSame((string) $a->id, (string) $row[0]['parent_id']);
+        $this->assertSame('entity_a', $row[0]['parent_type']);
+
+        $this->orm = $this->orm->withHeap(new Heap());
+        $reloaded = $this->orm->getRepository(EntityA::class)->findByPK($a->id);
+        $this->assertInstanceOf(EntityA::class, $reloaded->parent);
+        $this->assertSame($reloaded->id, $reloaded->parent->id);
+    }
+
+    public function testCreateCycleTwoEntities(): void
+    {
+        $a = new EntityA();
+        $a->name = 'cycle-a';
+
+        $b = new EntityB();
+        $b->name = 'cycle-b';
+
+        $a->parent = $b;
+        $b->parent = $a;
+
+        $this->captureWriteQueries();
+        $this->save($a);
+        // INSERT a, INSERT b, then a deferred UPDATE to close the cycle
+        $this->assertNumWrites(3);
+
+        // consecutive save does nothing
+        $this->captureWriteQueries();
+        $this->save($a);
+        $this->assertNumWrites(0);
+
+        $this->assertSame($b->id, $a->parentId);
+        $this->assertSame('entity_b', $a->parentType);
+        $this->assertSame($a->id, $b->parentId);
+        $this->assertSame('entity_a', $b->parentType);
+
+        $this->orm = $this->orm->withHeap(new Heap());
+
+        $reloadedA = $this->orm->getRepository(EntityA::class)->findByPK($a->id);
+        $this->assertInstanceOf(EntityB::class, $reloadedA->parent);
+        $this->assertSame($b->id, $reloadedA->parent->id);
+        $this->assertInstanceOf(EntityA::class, $reloadedA->parent->parent);
+        $this->assertSame($a->id, $reloadedA->parent->parent->id);
+    }
+
+    /**
+     * With ignoreUninitializedRelations = true (BaseTest default) unsetting the relation property
+     * must leave both the outer key and the morph key untouched.
+     */
+    public function testUnsetParentKeepsMorphWhenIgnoringUninitialized(): void
+    {
+        $a = $this->orm->getRepository(EntityA::class)->findByPK(1);
+        $this->assertInstanceOf(EntityA::class, $a->parent);
+        unset($a->parent);
+
+        $this->captureWriteQueries();
+        $this->save($a);
+        $this->assertNumWrites(0);
+
+        $row = $this->getDatabase()->table('entity_a')->select()->where('id', 1)->fetchAll();
+        $this->assertSame('1', (string) $row[0]['parent_id']);
+        $this->assertSame('entity_a', $row[0]['parent_type']);
+    }
+
+    /**
+     * With ignoreUninitializedRelations = false an unset relation is treated as null, so both the
+     * outer key and the morph key must be cleared.
+     */
+    public function testUnsetParentClearsMorphWithoutIgnoreUninitialized(): void
+    {
+        $this->orm = $this->orm->with(options: (new Options())->withIgnoreUninitializedRelations(false));
+
+        $a = $this->orm->getRepository(EntityA::class)->findByPK(1);
+        $this->assertInstanceOf(EntityA::class, $a->parent);
+        unset($a->parent);
+
+        $this->captureWriteQueries();
+        $this->save($a);
+        $this->assertNumWrites(1);
+
+        $row = $this->getDatabase()->table('entity_a')->select()->where('id', 1)->fetchAll();
+        $this->assertNull($row[0]['parent_id'], 'parent_id should be NULL when the unset relation is treated as null');
+        $this->assertNull($row[0]['parent_type'], 'parent_type should be NULL when the unset relation is treated as null');
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->makeTable('entity_a', [
+            'id' => 'primary',
+            'name' => 'string',
+            'parent_id' => 'integer,nullable',
+            'parent_type' => 'string,nullable',
+        ]);
+
+        $this->makeTable('entity_b', [
+            'id' => 'primary',
+            'name' => 'string',
+            'parent_id' => 'integer,nullable',
+            'parent_type' => 'string,nullable',
+        ]);
+
+        // entity_a #1 references itself; entity_a #2 -> entity_b #1
+        $this->getDatabase()->table('entity_a')->insertMultiple(
+            ['name', 'parent_id', 'parent_type'],
+            [
+                ['a-self', 1, 'entity_a'],
+                ['a-cycle', 1, 'entity_b'],
+            ],
+        );
+
+        // entity_b #1 -> entity_a #2 (closes the A > B > A cycle)
+        $this->getDatabase()->table('entity_b')->insertMultiple(
+            ['name', 'parent_id', 'parent_type'],
+            [
+                ['b-1', 2, 'entity_a'],
+            ],
+        );
+
+        $this->orm = $this->withSchema(new Schema([
+            EntityA::class => [
+                Schema::ROLE => 'entity_a',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'entity_a',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => [
+                    'id' => 'id',
+                    'name' => 'name',
+                    'parentId' => 'parent_id',
+                    'parentType' => 'parent_type',
+                ],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [
+                    'parent' => $this->morphedParent(),
+                ],
+            ],
+            EntityB::class => [
+                Schema::ROLE => 'entity_b',
+                Schema::MAPPER => Mapper::class,
+                Schema::DATABASE => 'default',
+                Schema::TABLE => 'entity_b',
+                Schema::PRIMARY_KEY => 'id',
+                Schema::COLUMNS => [
+                    'id' => 'id',
+                    'name' => 'name',
+                    'parentId' => 'parent_id',
+                    'parentType' => 'parent_type',
+                ],
+                Schema::SCHEMA => [],
+                Schema::RELATIONS => [
+                    'parent' => $this->morphedParent(),
+                ],
+            ],
+        ]));
+    }
+
+    private function morphedParent(): array
+    {
+        return [
+            Relation::TYPE => Relation::REFERS_TO_MORPHED,
+            Relation::TARGET => MorphedInterface::class,
+            Relation::LOAD => Relation::LOAD_PROMISE,
+            Relation::SCHEMA => [
+                Relation::NULLABLE => true,
+                Relation::CASCADE => true,
+                Relation::OUTER_KEY => 'id',
+                Relation::INNER_KEY => 'parentId',
+                Relation::MORPH_KEY => 'parentType',
+            ],
+        ];
+    }
+}

--- a/tests/ORM/Functional/Driver/Common/Relation/Morphed/RefersToMorphedCyclicTest.php
+++ b/tests/ORM/Functional/Driver/Common/Relation/Morphed/RefersToMorphedCyclicTest.php
@@ -10,6 +10,7 @@ use Cycle\ORM\Options;
 use Cycle\ORM\Reference\ReferenceInterface;
 use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
+use Cycle\ORM\Select;
 use Cycle\ORM\Tests\Functional\Driver\Common\BaseTest;
 use Cycle\ORM\Tests\Fixtures\MorphedCyclic\EntityA;
 use Cycle\ORM\Tests\Fixtures\MorphedCyclic\EntityB;
@@ -88,6 +89,48 @@ abstract class RefersToMorphedCyclicTest extends BaseTest
         // The back-reference entity_a #2 is already in the heap -> no extra query.
         $this->captureReadQueries();
         $this->assertSame($a, $b->parent);
+        $this->assertNumReads(0);
+    }
+
+    /**
+     * Eager loading via Select::load(): one level of the morphed relation is resolved up front
+     * (one query per distinct morph role), so accessing the parent afterwards costs no queries.
+     */
+    public function testEagerLoadParent(): void
+    {
+        /** @var list<EntityA> $all */
+        $all = (new Select($this->orm, EntityA::class))
+            ->load('parent')
+            ->orderBy('entity_a.id')
+            ->fetchAll();
+
+        $this->captureReadQueries();
+        // #1 references itself, #2 references entity_b #1 — both already loaded.
+        $this->assertInstanceOf(EntityA::class, $all[0]->parent);
+        $this->assertSame($all[0], $all[0]->parent);
+        $this->assertInstanceOf(EntityB::class, $all[1]->parent);
+        $this->assertSame('b-1', $all[1]->parent->name);
+        $this->assertNumReads(0);
+    }
+
+    /**
+     * The morphed relation can be eagerly loaded for a batch of already-fetched entities through
+     * the BulkLoader. After that, accessing the parent issues no extra queries.
+     */
+    public function testBulkLoadParent(): void
+    {
+        $this->captureReadQueries();
+        /** @var list<EntityA> $all */
+        $all = (new Select($this->orm, EntityA::class))->orderBy('entity_a.id')->fetchAll();
+        $this->assertNumReads(1);
+
+        $this->bulkLoader(...$all)->load('parent')->run();
+
+        $this->captureReadQueries();
+        $this->assertInstanceOf(EntityA::class, $all[0]->parent);
+        $this->assertSame($all[0], $all[0]->parent);
+        $this->assertInstanceOf(EntityB::class, $all[1]->parent);
+        $this->assertSame('b-1', $all[1]->parent->name);
         $this->assertNumReads(0);
     }
 

--- a/tests/ORM/Functional/Driver/MySQL/Relation/Morphed/RefersToMorphedCyclicTest.php
+++ b/tests/ORM/Functional/Driver/MySQL/Relation/Morphed/RefersToMorphedCyclicTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\MySQL\Relation\Morphed;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\Morphed\RefersToMorphedCyclicTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class RefersToMorphedCyclicTest extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/ORM/Functional/Driver/Postgres/Relation/Morphed/RefersToMorphedCyclicTest.php
+++ b/tests/ORM/Functional/Driver/Postgres/Relation/Morphed/RefersToMorphedCyclicTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\Postgres\Relation\Morphed;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\Morphed\RefersToMorphedCyclicTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class RefersToMorphedCyclicTest extends CommonClass
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/ORM/Functional/Driver/SQLServer/Relation/Morphed/RefersToMorphedCyclicTest.php
+++ b/tests/ORM/Functional/Driver/SQLServer/Relation/Morphed/RefersToMorphedCyclicTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLServer\Relation\Morphed;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\Morphed\RefersToMorphedCyclicTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class RefersToMorphedCyclicTest extends CommonClass
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/ORM/Functional/Driver/SQLite/Relation/Morphed/RefersToMorphedCyclicTest.php
+++ b/tests/ORM/Functional/Driver/SQLite/Relation/Morphed/RefersToMorphedCyclicTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Tests\Functional\Driver\SQLite\Relation\Morphed;
+
+// phpcs:ignore
+use Cycle\ORM\Tests\Functional\Driver\Common\Relation\Morphed\RefersToMorphedCyclicTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class RefersToMorphedCyclicTest extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+}


### PR DESCRIPTION
## 🔍 What was changed

Added a new morphed relation type `Relation::REFERS_TO_MORPHED` together with the `RefersToMorphed` relation class.

`RefersToMorphed` is to `BelongsToMorphed` what `RefersTo` is to `BelongsTo`: it stores both the outer key and the target role (morph key) on the owner entity, but resolves the outer key in a **deferred / "soft"** way instead of as a hard "parent before child" dependency.

- `src/Relation.php` — new `REFERS_TO_MORPHED` constant.
- `src/Relation/Morphed/RefersToMorphed.php` — new relation extending `RefersTo`; adds morph-key handling (reads the target role from the morph column in `initReference`, keeps the morph key in sync with the related entity role, and clears it when the relation is set to `null`).
- `src/Config/RelationConfig.php` — registers the type, **reusing** the existing `BelongsToMorphedLoader` (read semantics are identical).

> [!NOTE]
> The `#[RefersToMorphed]` attribute lives in the separate `cycle/annotated` package and is intentionally **not** part of this PR.

## 🤔 Why?

`BelongsToMorphed` inherits the hard ordering dependency of `BelongsTo`, so persisting a **closed cycle** through a morphed relation in a single transaction deadlocks the pool:

```
Pool has gone into an infinite loop.
```

This affects both self-references (`A > A`) and two-entity cycles (`A > B > A`). For non-morphed relations this is solved by `RefersTo`, but until now there was no morphed counterpart. `RefersToMorphed` allows such cyclic / self-linked morphed references to be saved within one transaction (INSERT + deferred UPDATE), exactly like `HasOne`/`RefersTo` cycles.

## 📝 Checklist

- How was this tested:
  - [x] Tested manually
  - [x] Unit tests added

Functional tests added for `A > A` and `A > B > A` (read, single-transaction create, detach to `null`) across **all four drivers** (SQLite, MySQL, Postgres, SQL Server). Additionally added coverage — previously missing — for the interaction of both morphed `belongs-to` / `refers-to` relations with `Options::$ignoreUninitializedRelations` (unset relation property is ignored when the option is `true`, and clears both the outer key and the morph key when `false`).

Full SQLite suite, unit tests, Psalm and PHP-CS-Fixer are green.

## 📃 Documentation

No documentation change shipped in this repo. A follow-up in `cycle/annotated` (the `#[RefersToMorphed]` attribute) and the docs site would complete the feature for end users.
